### PR TITLE
Remove unused re.T import causing crash on python 3.13

### DIFF
--- a/pixelblaze/pixelblaze.py
+++ b/pixelblaze/pixelblaze.py
@@ -77,7 +77,6 @@ import pathlib
 import pytz
 import traceback
 import gzip
-from re import T
 from typing import Union
 from enum import Enum, Flag, IntEnum, IntFlag
 from urllib.parse import urlparse, urljoin


### PR DESCRIPTION
re.T is removed in python 3.13, and wasn't even used in the current codebase.