### PR TITLE
py-mini-racer depreciation warning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setuptools.setup(
       "websocket-client",
       "requests",
       "pytz",
-      "py-mini-racer"
+      "mini-racer"
     ],
     packages=["pixelblaze"],
     python_requires='>=3.9',


### PR DESCRIPTION
`py-mini-racer` is currently depreciated and uses `pkg_resources` which is also depreciated.

This is causing warnings on import of pixelblaze: (why this is a user warning and not a depreciation warning is beyond me)

```
...\py_mini_racer.py:13: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
import pkg_resources
```

Current proposed solution is to upgrade `py-mini-racer` to `mini-racer` see [here](https://github.com/bpcreech/PyMiniRacer?tab=readme-ov-file#new-home-as-of-march-2024) for details on the depreciation

I have not however tested pixelblaze with the updated mini-racer.