### PR TITLE
Expand `pb` CLI + PB API (wifi, playlist, pattern I/O, filesystem)

### DIFF
--- a/examples/cli_examples.sh
+++ b/examples/cli_examples.sh
@@ -64,22 +64,26 @@ pb map --csv
 # =================
 
 # Start the sequencer
-pb seq play
+pb playlist play
 
 # Pause the sequencer
-pb seq pause
+pb playlist pause
 
 # Go to next pattern
-pb seq next
+pb playlist next
 
 # Jump to random pattern
-pb seq rand
+pb playlist rand
 
 # Set all patterns to 10 seconds
-pb seq len 10
+pb playlist len 10
 
 # Set all patterns to 30 seconds and save
-pb seq len 30 --save
+pb playlist len 30 --save
+
+# Save the playlist matching case insensitive CSV pattern name substrings,
+# each 15 seconds, shuffle the supplied order
+pb playlist set 'blink fade,block reflections,honeycom,xorc' --shuffle -d 15
 
 
 # Live Pattern Rendering (Temporary)

--- a/pixelblaze/cli/cli.py
+++ b/pixelblaze/cli/cli.py
@@ -27,7 +27,9 @@ import click
 import pathlib
 from pixelblaze.pixelblaze import Pixelblaze, PBB
 from pixelblaze.cli.cli_utils import cli, log, no_save_option, input_arg, read_input, parse_json, jsons, \
-                                     get_cache_dir, check, parse_vars, get_pixelblaze, discover_pixelblaze
+                                     get_cache_dir, check, parse_vars, get_pixelblaze, discover_pixelblaze, \
+                                     enumerate_pixelblazes, cache_ip, _read_cache, _write_cache, \
+                                     _fetch_device_config, update_device_cache, lookup_cached_device
 
 @click.group()
 @click.option(
@@ -43,8 +45,15 @@ from pixelblaze.cli.cli_utils import cli, log, no_save_option, input_arg, read_i
     help='Command timeout in seconds (default: 5.0)',
     show_default=True
 )
+@click.option(
+    '--retries',
+    type=int,
+    default=3,
+    help='Number of retries on connection errors (default: 3)',
+    show_default=True
+)
 @click.pass_context
-def pixelblaze(ctx, ip, timeout):
+def pixelblaze(ctx, ip, timeout, retries):
     """
     Pixelblaze LED Controller CLI
 
@@ -53,6 +62,88 @@ def pixelblaze(ctx, ip, timeout):
     ctx.ensure_object(dict)
     ctx.obj['ip'] = ip
     ctx.obj['timeout'] = timeout
+    ctx.obj['retries'] = retries
+
+
+@pixelblaze.command()
+@click.option('--name', '-n', 'name_filter', default=None,
+              help='Filter by device name (case-insensitive substring match, implies --full)')
+@click.option('--ip', '-i', 'ip_filter', default=None,
+              help='Filter by IP address (substring match)')
+@click.option('--timeout', '-t', 'scan_timeout', type=int, default=3000,
+              help='Beacon listen timeout in milliseconds (default: 3000)',
+              show_default=True)
+@click.option('--full', '--slow', '-s', '-f', 'slow', is_flag=True,
+              help='Connect to each device to fetch name, version, config (parallel)')
+@click.option('--no-cache', is_flag=True, help='Do not cache the selected IP')
+@click.pass_context
+def find(ctx, name_filter, ip_filter, scan_timeout, slow, no_cache):
+    """
+    Discover and enumerate all Pixelblazes on the network.
+
+    By default runs fast: listens for UDP beacons and returns IPs only.
+    Use --full/--slow to connect to each device (in parallel) and fetch names,
+    version, pixel count, etc. Using --name implies --full.
+
+    Prints JSONL (one JSON object per line) to stdout. Discovery progress
+    is logged to stderr.
+
+    The first matching device (after any filters) is cached as the default
+    IP for subsequent commands.
+
+    \b
+    Examples:
+        pb find                          # Fast: just IPs from beacons
+        pb find --full                   # Connect to each, get full info (--slow is an alias)
+        pb find --name living            # Filter by name (implies --full)
+        pb find --ip 192.168.1           # Filter by IP substring (fast)
+        pb find --name tree --ip 10.     # Combine filters
+        pb find --timeout 5000           # Scan longer for slow networks
+        pb find --no-cache               # Don't update cached IP
+        pb find 2>/dev/null              # Quiet mode (stdout JSONL only)
+    """
+    # --name requires device info, so imply --full
+    if name_filter:
+        slow = True
+
+    devices = enumerate_pixelblazes(timeout=scan_timeout, slow=slow)
+
+    if not devices:
+        raise click.ClickException("No Pixelblazes found on the network.")
+
+    # Apply filters
+    matched = []
+    for dev in devices:
+        if name_filter and name_filter.lower() not in dev.get('name', '').lower():
+            continue
+        if ip_filter and ip_filter not in dev.get('ip', ''):
+            continue
+        matched.append(dev)
+
+    log(f"\nFound {len(devices)} device(s), {len(matched)} matched filters.")
+
+    if not matched:
+        filters = []
+        if name_filter:
+            filters.append(f"--name '{name_filter}'")
+        if ip_filter:
+            filters.append(f"--ip '{ip_filter}'")
+        raise click.ClickException(
+            f"No devices matched filters: {' '.join(filters)}. "
+            f"Found {len(devices)} device(s) total."
+        )
+
+    # Print all matched devices as JSONL to stdout
+    for dev in matched:
+        click.echo(jsonlib.dumps(dev, separators=(',', ':')))
+
+    # Cache the first match
+    selected = matched[0]
+    if not no_cache:
+        cache_ip(selected['ip'])
+        log(f"Cached IP: {selected['ip']}" + (f" ({selected['name']})" if selected.get('name') else ""))
+    else:
+        log(f"Selected (not cached): {selected['ip']}" + (f" ({selected['name']})" if selected.get('name') else ""))
 
 
 @cli(pixelblaze)
@@ -72,7 +163,18 @@ def pixels(pb: Pixelblaze, count, no_save):
         current_count = pb.getPixelCount()
         click.echo(f"{current_count}")
     else:
-        pb.setPixelCount(count, saveToFlash=not no_save)
+        current_count = pb.getPixelCount()
+        if count < current_count:
+            # Blank orphaned LEDs by toggling brightness off around the change
+            log(f"Reducing pixel count ({current_count} → {count})...")
+            prev_brightness = pb.getBrightnessSlider()
+            pb.setBrightnessSlider(0.0)
+            time.sleep(0.1)
+            pb.setPixelCount(count, saveToFlash=not no_save)
+            time.sleep(0.1)
+            pb.setBrightnessSlider(prev_brightness)
+        else:
+            pb.setPixelCount(count, saveToFlash=not no_save)
         action = "set" if no_save else "saved"
         log(f"Pixel count {action} to {count}")
 
@@ -146,9 +248,10 @@ def off(pb: Pixelblaze, pause_sequencer, no_save):
 @cli(pixelblaze)
 @input_arg
 @click.option('--csv', is_flag=True, help='Output as csv instead of Pixelblaze 3-arrays')
-def map(pb: Pixelblaze, input, csv):
+@click.option('--clear', is_flag=True, help='Clear/remove the current pixel map from the device')
+def map(pb: Pixelblaze, input, csv, clear):
     """
-    Get or set the pixel map function.
+    Get, set, or clear the pixel map function.
 
     INPUT is an optional JavaScript file path or inline code. Can also be
     piped via stdin. If no input is provided, the current map function
@@ -159,7 +262,17 @@ def map(pb: Pixelblaze, input, csv):
         pb map                       # Get current map coordinates (normalized 0-1)
         pb map map.js                # Set map from file
         pb map < map.js              # Set map from stdin
+        pb map --clear               # Remove the current pixel map
     """
+    check(not (clear and csv), "Cannot use --clear and --csv together")
+
+    if clear:
+        log("Clearing pixel map...")
+        pb.deleteFile('/pixelmap.txt')
+        pb.deleteFile('/pixelmap.dat')
+        log("Pixel map cleared")
+        return
+
     content, _ = read_input(input, "map", required=False)
     setting = content is not None
 
@@ -183,9 +296,9 @@ def map(pb: Pixelblaze, input, csv):
 
 
 @pixelblaze.group()
-def seq():
+def playlist():
     """
-    Sequencer and playlist control commands.
+    Playlist and sequencer control commands.
 
     Control the Pixelblaze pattern sequencer, including play/pause,
     navigation, and playlist management.
@@ -193,7 +306,7 @@ def seq():
     pass
 
 
-@cli(seq)
+@cli(playlist)
 @no_save_option
 def pause(pb: Pixelblaze, no_save):
     """
@@ -201,8 +314,8 @@ def pause(pb: Pixelblaze, no_save):
 
     \b
     Examples:
-        pb seq pause           # Pause sequencer (saved to flash)
-        pb seq pause --no-save    # Pause (temporary only)
+        pb playlist pause           # Pause sequencer (saved to flash)
+        pb playlist pause --no-save    # Pause (temporary only)
     """
     log("Pausing sequencer...")
     pb.pauseSequencer(saveToFlash=not no_save)
@@ -210,7 +323,7 @@ def pause(pb: Pixelblaze, no_save):
     log(f"Sequencer {action}")
 
 
-@cli(seq)
+@cli(playlist)
 @no_save_option
 def play(pb: Pixelblaze, no_save):
     """
@@ -218,8 +331,8 @@ def play(pb: Pixelblaze, no_save):
 
     \b
     Examples:
-        pb seq play           # Start/resume sequencer (saved to flash)
-        pb seq play --no-save    # Start (temporary only)
+        pb playlist play           # Start/resume sequencer (saved to flash)
+        pb playlist play --no-save    # Start (temporary only)
     """
     log("Starting sequencer...")
     pb.playSequencer(saveToFlash=not no_save)
@@ -227,7 +340,7 @@ def play(pb: Pixelblaze, no_save):
     log(f"Sequencer {action}")
 
 
-@cli(seq)
+@cli(playlist)
 @no_save_option
 def next(pb: Pixelblaze, no_save):
     """
@@ -237,8 +350,8 @@ def next(pb: Pixelblaze, no_save):
 
     \b
     Examples:
-        pb seq next           # Next pattern (saved to flash)
-        pb seq next --no-save    # Next pattern (temporary only)
+        pb playlist next           # Next pattern (saved to flash)
+        pb playlist next --no-save    # Next pattern (temporary only)
     """
     log("Advancing to next pattern...")
     pb.nextSequencer(saveToFlash=not no_save)
@@ -246,7 +359,7 @@ def next(pb: Pixelblaze, no_save):
     log(action)
 
 
-@cli(seq)
+@cli(playlist)
 def rand(pb: Pixelblaze):
     """
     Jump to a random pattern.
@@ -255,7 +368,7 @@ def rand(pb: Pixelblaze):
 
     \b
     Examples:
-        pb seq rand    # Jump to random pattern
+        pb playlist rand    # Jump to random pattern
     """
     import random as rand
 
@@ -272,7 +385,7 @@ def rand(pb: Pixelblaze):
     log(f"Now playing: {pattern_name}")
 
 
-@cli(seq, name='len')
+@cli(playlist, name='len')
 @click.argument('seconds', type=float)
 @no_save_option
 def set_duration(pb: Pixelblaze, seconds, no_save):
@@ -285,8 +398,8 @@ def set_duration(pb: Pixelblaze, seconds, no_save):
 
     \b
     Examples:
-        pb seq len 10          # Set all durations to 10 seconds (saved)
-        pb seq len 30 --no-save   # Set to 30 seconds (temporary only)
+        pb playlist len 10          # Set all durations to 10 seconds (saved)
+        pb playlist len 30 --no-save   # Set to 30 seconds (temporary only)
     """
     check(seconds > 0, "Duration must be greater than 0")
 
@@ -310,6 +423,112 @@ def set_duration(pb: Pixelblaze, seconds, no_save):
 
     action = "set" if no_save else "saved"
     log(f"Playlist updated and {action}: all patterns set to {seconds}s")
+
+
+@cli(playlist, name='set')
+@click.argument('terms', type=str)
+@click.option('--duration', '-d', type=float, default=30.0,
+              show_default=True, help='Seconds per pattern')
+@click.option('--shuffle', is_flag=True,
+              help='Shuffle the resolved order before writing the playlist')
+@no_save_option
+def playlist_set(pb: Pixelblaze, terms, duration, shuffle, no_save):
+    """
+    Build a playlist from a CSV of pattern-name searches and/or .js file paths, then play it.
+
+    For each comma-separated term:
+      1. case-insensitive substring match against stored pattern names, or
+      2. treated as a local .js file path — uploaded to the device, then used.
+
+    Unresolved terms are logged and skipped (best-effort — never fails the whole run).
+    Quote the whole arg if any term contains spaces or shell-special characters.
+
+    \b
+    Examples:
+        pb playlist set 'sparkle,rainbow,wave'
+        pb playlist set 'src/patterns/tools/colorOrder.js,sparkle' -d 10
+        pb playlist set 'foo,bar,baz' --no-save
+    """
+    check(terms.strip(), "Provide a comma-separated list of names or .js file paths")
+    check(duration > 0, "Duration must be greater than 0")
+
+    parts = [t.strip() for t in terms.split(',') if t.strip()]
+    check(parts, "No terms provided")
+
+    log("Fetching pattern list...")
+    patterns = dict(pb.getPatternList())  # {id: name}; local copy so we can extend it
+
+    resolved = []  # [(patternId, displayName), ...]
+
+    for term in parts:
+        t_lower = term.lower()
+        matches = [(pid, name) for pid, name in patterns.items()
+                   if t_lower in name.lower()]
+        if matches:
+            pid, name = matches[0]
+            resolved.append((pid, name))
+            extra = ''
+            if len(matches) > 1:
+                others = ', '.join(n for _, n in matches[1:4])
+                more = '...' if len(matches) > 4 else ''
+                extra = f"  [+{len(matches) - 1} more: {others}{more}]"
+            log(f"  ✓ '{term}' → {name}{extra}")
+            continue
+
+        path = pathlib.Path(term)
+        if path.is_file() and path.suffix.lower() == '.js':
+            try:
+                code = path.read_text()
+                if 'export' not in code:
+                    code = 'export function render(index) { ' + code + ' ; }'
+                pattern_name = path.stem
+                existing_pid = next(
+                    (pid for pid, name in patterns.items()
+                     if name.lower() == pattern_name.lower()),
+                    None
+                )
+                img_path = pathlib.Path(__file__).parent / '../../site/images/preview_placeholder.jpg'
+                preview = img_path.read_bytes()
+                verb = 'updating' if existing_pid else 'uploading'
+                log(f"  ↑ '{term}' → {verb} '{pattern_name}'")
+                pid = pb.savePattern(
+                    previewImage=preview,
+                    sourceCode=code,
+                    name=pattern_name,
+                    id=existing_pid,
+                    allowCache=True,
+                )
+                resolved.append((pid, pattern_name))
+                patterns[pid] = pattern_name  # so later terms can name-match this
+                continue
+            except Exception as e:
+                log(f"  ✗ '{term}' → file upload failed: {e}; skipping")
+                continue
+
+        log(f"  ✗ '{term}' → no name match and not a .js file; skipping")
+
+    check(resolved, "No terms resolved to a pattern; playlist unchanged")
+
+    if shuffle:
+        import random as rand
+        rand.shuffle(resolved)
+        log(f"Shuffled order: {', '.join(name for _, name in resolved)}")
+
+    ms_per = int(duration * 1000)
+    log("Building playlist...")
+    playlist = pb.getSequencerPlaylist()
+    playlist['playlist']['items'] = [{"id": pid, "ms": ms_per} for pid, _ in resolved]
+
+    log(f"Setting playlist ({len(resolved)} pattern{'s' if len(resolved) != 1 else ''}, "
+        f"{duration}s each)...")
+    pb.setSequencerPlaylist(playlist, saveToFlash=not no_save)
+
+    log("Switching to Playlist mode and starting...")
+    pb.setSequencerMode(Pixelblaze.sequencerModes.Playlist, saveToFlash=not no_save)
+    pb.playSequencer(saveToFlash=not no_save)
+
+    action = "set (temporary)" if no_save else "saved"
+    log(f"Playlist {action}. Playing: {resolved[0][1]}")
 
 
 @cli(pixelblaze)
@@ -508,29 +727,40 @@ def _find_pattern(pb: Pixelblaze, search: str, exact: bool = False):
     Returns:
         tuple: (pattern_id, pattern_name) or (None, None) if not found
     """
+    results = _find_patterns(pb, search, exact)
+    return results[0] if results else (None, None)
+
+
+def _find_patterns(pb: Pixelblaze, search: str, exact: bool = False):
+    """Find all patterns matching a name or ID.
+
+    Returns:
+        list[tuple]: List of (pattern_id, pattern_name) tuples
+    """
     log("Fetching pattern list...")
     patterns = pb.getPatternList()
 
     # Try by ID first
     if Pixelblaze.isPatternId(search):
         pattern_name = patterns.get(search)
-        return (search, pattern_name) if pattern_name else (None, None)
+        return [(search, pattern_name)] if pattern_name else []
 
     # Search by name
     if not patterns:
-        return (None, None)
+        return []
 
     pattern_regex = re.compile(search, re.IGNORECASE)
+    results = []
 
     for pattern_id, pattern_name in patterns.items():
         if exact:
             if pattern_name.lower() == search.lower():
-                return (pattern_id, pattern_name)
+                results.append((pattern_id, pattern_name))
         else:
             if pattern_regex.search(pattern_name):
-                return (pattern_id, pattern_name)
+                results.append((pattern_id, pattern_name))
 
-    return (None, None)
+    return results
 
 
 def _handle_cat_mode(pb: Pixelblaze, input, exact):
@@ -580,7 +810,8 @@ def _handle_write_mode(pb: Pixelblaze, input, write_target, img, variables, no_s
         check(pattern_name, f"Pattern ID {write_target} not found")
     else:
         pattern_name = write_target
-        pattern_id = None
+        # Look up existing pattern by name to overwrite instead of creating a dupe
+        pattern_id, _ = _find_pattern(pb, write_target, exact=True)
 
     if "export" not in code:
         code = 'export function render(index) { ' + code + ' ; }'
@@ -590,7 +821,9 @@ def _handle_write_mode(pb: Pixelblaze, input, write_target, img, variables, no_s
     with open(img, 'rb') as f:
         preview_image = f.read()
 
-    log(f"Saving pattern '{pattern_name}' (Supplied ID: {pattern_id})...")
+    is_update = pattern_id is not None
+    log(f"{'Updating' if is_update else 'Creating'} pattern '{pattern_name}'"
+        f"{f' (ID: {pattern_id})' if is_update else ''}...")
     pattern_id = pb.savePattern(
         previewImage=preview_image,
         sourceCode=code,
@@ -599,7 +832,7 @@ def _handle_write_mode(pb: Pixelblaze, input, write_target, img, variables, no_s
         allowCache=True
     )
 
-    log(f"Pattern '{pattern_name}' (ID: {pattern_id}) created successfully!")
+    log(f"Pattern '{pattern_name}' (ID: {pattern_id}) {'updated' if is_update else 'created'} successfully!")
     _set_vars_and_controls(pb, variables, not no_save)
     jsons({'id': pattern_id})
 
@@ -664,30 +897,448 @@ def _set_vars_and_controls(pb: Pixelblaze, variables, save=False):
 
 
 @cli(pixelblaze)
-def cfg(pb: Pixelblaze):
+@click.option('--name', 'device_name', default=None, help='Set device name')
+@click.option('--pixels', type=int, default=None, help='Set pixel count')
+@click.option('--brightness', type=float, default=None, help='Set brightness (0.0-1.0)')
+@click.option('--max-brightness', type=int, default=None, help='Set brightness limit (0-100%%)')
+@click.option('--led-type',
+              type=click.Choice(['WS2812', 'APA102', 'SK9822', 'WS2801', 'OutputExpander', 'off'],
+                                case_sensitive=False),
+              default=None, help='Set LED type')
+@click.option('--color-order',
+              type=click.Choice(['RGB', 'RBG', 'BRG', 'BGR', 'GRB', 'GBR',
+                                 'RGBW', 'GRBW', 'RGB-W', 'GRB-W'],
+                                case_sensitive=False),
+              default=None, help='Set color order')
+@click.option('--data-speed', type=int, default=None, help='Set LED data speed (Hz, advanced)')
+@click.option('--cpu',
+              type=click.Choice(['low', 'medium', 'high'], case_sensitive=False),
+              default=None, help='Set CPU speed (80/160/240 MHz, requires reboot)')
+@click.option('--discovery/--no-discovery', default=None,
+              help='Enable/disable Electromage discovery service')
+@click.option('--timezone', 'tz', default=None, help='Set timezone (Unix tz string, e.g. "America/New_York")')
+@click.option('--auto-off/--no-auto-off', 'auto_off_enable', default=None,
+              help='Enable/disable auto-off scheduler')
+@click.option('--auto-off-start', default=None, help='Auto-off start time (HH:MM)')
+@click.option('--auto-off-end', default=None, help='Auto-off end time (HH:MM)')
+@click.option('--network-power-save/--no-network-power-save', 'net_power_save', default=None,
+              help='Enable/disable WiFi power save (requires reboot)')
+@click.option('--simple-ui/--no-simple-ui', 'simple_ui', default=None,
+              help='Enable/disable Simple UI mode')
+@click.option('--learning-ui/--no-learning-ui', 'learning_ui', default=None,
+              help='Enable/disable Learning UI mode')
+@click.option('--brand-name', default=None, help='Set brand name (VAR/OEM use)')
+@click.option('--leader-id', type=int, default=None,
+              help='Group-sync leader chipId to follow (0 = Solo/Leader)')
+@click.option('--node-id', type=int, default=None,
+              help="This device's sync-group node id (readable in patterns via nodeId())")
+@no_save_option
+def cfg(pb: Pixelblaze, device_name, pixels, brightness, max_brightness,
+        led_type, color_order, data_speed, cpu, discovery, tz,
+        auto_off_enable, auto_off_start, auto_off_end,
+        net_power_save, simple_ui, learning_ui, brand_name,
+        leader_id, node_id, no_save):
     """
-    Fetch and display most of the configuration from the Pixelblaze.
+    Get or set Pixelblaze configuration.
 
-    This mimics the web UI's initial configuration fetch, retrieving:
-    - Device config
-    - Pattern list
-    - Playlist
-    - Sequencer settings
-    - And more
+    With no options, fetches and displays the full configuration as JSON.
+    With options, sets the specified values (multiple can be combined).
 
     \b
     Examples:
-        pb cfg
-        pb cfg | yq -P          # Pretty-printed YAML
+        pb cfg                                  # Show full config
+        pb cfg | jq .config.name                # Query a field
+        pb cfg --name "My Pixelblaze"           # Set device name
+        pb cfg --pixels 300 --brightness 0.5    # Set multiple values
+        pb cfg --led-type WS2812 --color-order GRB
+        pb cfg --led-type APA102 --data-speed 2000000
+        pb cfg --cpu high                       # Requires reboot
+        pb cfg --discovery --timezone America/New_York
+        pb cfg --auto-off --auto-off-start 23:00 --auto-off-end 07:00
+        pb cfg --leader-id 0 --node-id 1        # Solo/Leader as node 1
+        pb cfg --leader-id 9238196 --node-id 2  # Follow leader by chipId
+        pb cfg --no-save --brightness 0.2       # Temporary only
     """
-    log("Fetching configurations...")
-    jsons({
-        'config': pb.getConfigSettings(),
-        'patterns': pb.getPatternList(),
-        'playlist': pb.getSequencerPlaylist(),
-        'sequencer': pb.getConfigSequencer()
-    })
+    save = not no_save
 
+    # Collect all set operations
+    changes = {}
+
+    if device_name is not None:
+        pb.setDeviceName(device_name)
+        changes['name'] = device_name
+
+    if pixels is not None:
+        check(pixels > 0, "Pixel count must be positive")
+        pb.setPixelCount(pixels, saveToFlash=save)
+        changes['pixelCount'] = pixels
+
+    if brightness is not None:
+        check(0.0 <= brightness <= 1.0, "Brightness must be between 0.0 and 1.0")
+        pb.setBrightnessSlider(brightness, saveToFlash=save)
+        changes['brightness'] = brightness
+
+    if max_brightness is not None:
+        check(0 <= max_brightness <= 100, "Max brightness must be between 0 and 100")
+        pb.setBrightnessLimit(max_brightness, saveToFlash=save)
+        changes['maxBrightness'] = max_brightness
+
+    if led_type is not None:
+        led_type_map = {
+            'ws2812': Pixelblaze.ledTypes.WS2812,
+            'apa102': Pixelblaze.ledTypes.APA102,
+            'sk9822': Pixelblaze.ledTypes.SK9822,
+            'ws2801': Pixelblaze.ledTypes.WS2801,
+            'outputexpander': Pixelblaze.ledTypes.OutputExpander,
+            'off': Pixelblaze.ledTypes.noLeds,
+        }
+        lt = led_type_map[led_type.lower()]
+        pb.setLedType(lt, dataSpeed=data_speed, saveToFlash=save)
+        changes['ledType'] = led_type
+        if data_speed is not None:
+            changes['dataSpeed'] = data_speed
+    elif data_speed is not None:
+        pb.setDataSpeed(data_speed, saveToFlash=save)
+        changes['dataSpeed'] = data_speed
+
+    if color_order is not None:
+        co = Pixelblaze.colorOrders(color_order.upper())
+        pb.setColorOrder(co, saveToFlash=save)
+        changes['colorOrder'] = color_order
+
+    if cpu is not None:
+        cpu_map = {
+            'low': Pixelblaze.cpuSpeeds.low,
+            'medium': Pixelblaze.cpuSpeeds.medium,
+            'high': Pixelblaze.cpuSpeeds.high,
+        }
+        pb.setCpuSpeed(cpu_map[cpu.lower()])
+        changes['cpuSpeed'] = cpu
+        log("Note: CPU speed change requires reboot to take effect")
+
+    if discovery is not None:
+        pb.setDiscovery(discovery, timezoneName=tz)
+        changes['discoveryEnable'] = discovery
+        if tz is not None:
+            changes['timezone'] = tz
+    elif tz is not None:
+        pb.setTimezone(tz)
+        changes['timezone'] = tz
+
+    if auto_off_enable is not None:
+        pb.setAutoOffEnable(auto_off_enable, saveToFlash=save)
+        changes['autoOffEnable'] = auto_off_enable
+
+    if auto_off_start is not None:
+        pb.setAutoOffStart(auto_off_start, saveToFlash=save)
+        changes['autoOffStart'] = auto_off_start
+
+    if auto_off_end is not None:
+        pb.setAutoOffEnd(auto_off_end, saveToFlash=save)
+        changes['autoOffEnd'] = auto_off_end
+
+    if net_power_save is not None:
+        pb.setNetworkPowerSave(net_power_save)
+        changes['networkPowerSave'] = net_power_save
+        log("Note: Network power save change requires reboot to take effect")
+
+    if simple_ui is not None:
+        pb.setSimpleUiMode(simple_ui)
+        changes['simpleUiMode'] = simple_ui
+
+    if learning_ui is not None:
+        pb.setLearningUiMode(learning_ui)
+        changes['learningUiMode'] = learning_ui
+
+    if brand_name is not None:
+        pb.setBrandName(brand_name)
+        changes['brandName'] = brand_name
+
+    # Group-sync: leaderId + nodeId bundled in one payload so they commit atomically
+    sync_payload = {}
+    if leader_id is not None:
+        sync_payload['leaderId'] = leader_id
+    if node_id is not None:
+        sync_payload['nodeId'] = node_id
+    if sync_payload:
+        sync_payload['save'] = save
+        pb.wsSendJson(sync_payload, expectedResponse=None)
+        if leader_id is not None:
+            changes['leaderId'] = leader_id
+            if leader_id == 0:
+                log("Note: leaderId=0 → Solo/Leader mode (this device broadcasts or runs standalone)")
+            else:
+                log(f"Note: this device will follow leader chipId={leader_id}")
+        if node_id is not None:
+            changes['nodeId'] = node_id
+
+    if changes:
+        for k, v in changes.items():
+            log(f"  {k}: {v}")
+        action = "set" if no_save else "saved"
+        log(f"{len(changes)} setting(s) {action}")
+    else:
+        # No options — read mode: dump full config
+        log("Fetching configurations...")
+        try:
+            wifi = Pixelblaze.getWifiStatus(pb.ipAddress)
+            try:
+                wifi['mode'] = Pixelblaze.wifiModes(wifi['status']).name
+            except (ValueError, KeyError):
+                pass
+        except Exception as e:
+            wifi = {'error': str(e)}
+        jsons({
+            'config': pb.getConfigSettings(),
+            'wifi': wifi,
+            'patterns': pb.getPatternList(),
+            'playlist': pb.getSequencerPlaylist(),
+            'sequencer': pb.getConfigSequencer()
+        })
+
+
+## ─── WiFi ─────────────────────────────────────────────────────────────────────
+
+@pixelblaze.group()
+def wifi():
+    """
+    WiFi configuration commands.
+
+    View WiFi status, scan for networks, join a network, or configure
+    the Pixelblaze as an access point. These commands use HTTP-only
+    endpoints and work in ad-hoc/setup mode (192.168.4.1).
+    """
+    pass
+
+
+@cli(wifi, conn=False)
+def status(ctx):
+    """
+    Show the current WiFi status.
+
+    Displays mode (setup/AP/client), IP address, SSID, and MAC address.
+
+    \b
+    Examples:
+        pb wifi status
+        pb wifi status --ip 192.168.4.1
+    """
+    ip = discover_pixelblaze(ctx)
+    log(f"Fetching WiFi status from {ip}...")
+    result = Pixelblaze.getWifiStatus(ip, timeout=ctx.obj['timeout'])
+
+    mode_names = {255: 'setup', 6: 'ap', 3: 'client'}
+    mode = result.get('status', -1)
+    result['modeName'] = mode_names.get(mode, f'unknown({mode})')
+    jsons(result)
+
+
+@cli(wifi, conn=False)
+def scan(ctx):
+    """
+    Scan for available WiFi networks.
+
+    Initiates a WiFi scan and displays nearby access points sorted by
+    signal strength, including SSID, signal (RSSI), channel, and security.
+
+    \b
+    Examples:
+        pb wifi scan
+        pb wifi scan --ip 192.168.4.1
+    """
+    ip = discover_pixelblaze(ctx)
+    log(f"Scanning for WiFi networks from {ip}...")
+    results = Pixelblaze.getWifiScan(ip, timeout=ctx.obj['timeout'] * 3)
+
+    if not results:
+        log("No networks found (scan may still be in progress, try again)")
+        return
+
+    results.sort(key=lambda ap: ap.get('rssi', -999), reverse=True)
+    jsons(results)
+
+    log(f"\n  {'SSID':<32} {'RSSI':>5}  {'CH':>3}  {'SECURE'}")
+    log(f"  {'─' * 32} {'─' * 5}  {'─' * 3}  {'─' * 6}")
+    for ap in results:
+        ssid = ap.get('ssid', '?')
+        rssi = ap.get('rssi', '?')
+        ch = ap.get('channel', '?')
+        secure = 'yes' if ap.get('secure') else 'no'
+        log(f"  {ssid:<32} {rssi:>5}  {ch:>3}  {secure}")
+
+
+@cli(wifi, conn=False)
+@click.option('--ssid', '-s', required=True, help='SSID of the network to join')
+@click.option('--password', '-p', default='', help='Network password (empty for open networks)')
+@click.option('--no-discover', is_flag=True, help='Disable Electromage discovery service')
+def join(ctx, ssid, password, no_discover):
+    """
+    Join a WiFi network as a client.
+
+    Connects the Pixelblaze to an existing WiFi network. After joining,
+    the device will be reachable at its new IP (check your router or
+    run 'pb find' on the target network).
+
+    \b
+    Examples:
+        pb wifi join -s "MyNetwork" -p "secret"
+        pb wifi join --ssid "OpenNetwork"
+        pb wifi join -s "MyNet" -p "pass" --no-discover
+    """
+    ip = discover_pixelblaze(ctx)
+    log(f"Joining network '{ssid}' from {ip}...")
+    result = Pixelblaze.setWifiConfig(ip, mode="CLIENT", ssid=ssid, passphrase=password,
+                                      discover=not no_discover, timeout=ctx.obj['timeout'])
+    jsons(result)
+    log(f"WiFi config saved — device will connect to '{ssid}'")
+    log(f"Use 'pb find' on the target network to discover the new IP")
+
+
+@cli(wifi, conn=False)
+@click.option('--ssid', '-s', required=True, help='SSID (network name) for the access point')
+@click.option('--password', '-p', default='', help='Password for the access point (leave empty for open)')
+def ap(ctx, ssid, password):
+    """
+    Configure the Pixelblaze as a WiFi access point.
+
+    Sets the Pixelblaze to create its own WiFi network with the
+    given name and optional password.
+
+    \b
+    Examples:
+        pb wifi ap -s "MyPixelblaze"        # Open AP network
+        pb wifi ap -s "MyPB" -p "secret"    # AP with password
+    """
+    ip = discover_pixelblaze(ctx)
+    log(f"Setting AP mode '{ssid}' on {ip}...")
+    result = Pixelblaze.setWifiConfig(ip, mode="AP", ssid=ssid, passphrase=password,
+                                      timeout=ctx.obj['timeout'])
+    jsons(result)
+    log(f"AP mode configured — network will be '{ssid}'")
+
+
+@cli(wifi, conn=False)
+def setup(ctx):
+    """
+    Reset WiFi to setup mode.
+
+    Puts the Pixelblaze back into initial setup mode, equivalent to
+    holding the button on boot. The device will create a 'Pixelblaze_*'
+    network for configuration.
+
+    \b
+    Examples:
+        pb wifi setup
+    """
+    ip = discover_pixelblaze(ctx)
+    log(f"Resetting to setup mode on {ip}...")
+    result = Pixelblaze.setWifiConfig(ip, mode="SETUP", timeout=ctx.obj['timeout'])
+    jsons(result)
+    log("WiFi reset to setup mode — look for a 'Pixelblaze_*' network")
+
+
+## ─── Cat ──────────────────────────────────────────────────────────────────────
+
+def _strip_js(source: str) -> str:
+    """Strip JS comments (single-line, multi-line) and blank lines."""
+    # Remove multi-line comments
+    source = re.sub(r'/\*.*?\*/', '', source, flags=re.DOTALL)
+    # Remove single-line comments (but not URLs like http://)
+    source = re.sub(r'(?<!:)//.*$', '', source, flags=re.MULTILINE)
+    # Remove blank lines
+    lines = [line for line in source.splitlines() if line.strip()]
+    return '\n'.join(lines)
+
+
+@cli(pixelblaze)
+@click.argument('path', required=False)
+@click.option('--full', is_flag=True, help='Output full source (keep comments and blank lines)')
+@click.option('--exact', is_flag=True, help='Match pattern name exactly (no regex/substring)')
+@click.option('--one', is_flag=True, help='Output only the first matching pattern (default: all matches)')
+def cat(pb: Pixelblaze, path, full, exact, one):
+    """
+    Output file or pattern source code from the Pixelblaze.
+
+    Without PATH, outputs the currently active pattern's source code.
+    With PATH, outputs ALL matching patterns' source code (use --one
+    for just the first match).
+
+    By default, strips JS comments and blank lines. Use --full to
+    output the raw, unmodified source.
+
+    \b
+    Examples:
+        pb cat                          # Active pattern source (stripped)
+        pb cat --full                   # Active pattern source (full)
+        pb cat sound                    # All patterns matching "sound"
+        pb cat sound --one              # First pattern matching "sound"
+        pb cat "color.*fade" --exact    # Exact name match
+        pb cat /config.json             # File from filesystem
+        pb cat /pixelmap.txt            # Pixel map function
+    """
+    # If path starts with /, treat as filesystem path
+    if path and path.startswith('/'):
+        log(f"Fetching file: {path}")
+        content = pb.getFile(path)
+        check(content is not None, f"File '{path}' not found on Pixelblaze")
+        try:
+            text = content.decode('utf-8')
+        except UnicodeDecodeError:
+            # Binary file — write raw bytes to stdout
+            import sys
+            sys.stdout.buffer.write(content)
+            return
+        if not full:
+            text = _strip_js(text)
+        click.echo(text)
+        return
+
+    # Pattern mode: find by name/ID, or use active pattern
+    if path:
+        if one:
+            matches = []
+            result = _find_pattern(pb, path, exact)
+            if result[0]:
+                matches = [result]
+        else:
+            matches = _find_patterns(pb, path, exact)
+        check(matches, f"No patterns matching '{path}' on Pixelblaze")
+    else:
+        log("Fetching active pattern...")
+        pattern_id = pb.getActivePattern()
+        check(pattern_id, "No active pattern running")
+        patterns = pb.getPatternList()
+        pattern_name = patterns.get(pattern_id, pattern_id)
+        matches = [(pattern_id, pattern_name)]
+
+    for i, (pattern_id, pattern_name) in enumerate(matches):
+        if len(matches) > 1:
+            if i > 0:
+                click.echo("")
+            click.echo(f"// ═══ {pattern_name} ({pattern_id}) ═══")
+
+        log(f"Fetching source: '{pattern_name}' ({pattern_id})")
+        source_code = pb.getPatternSourceCode(pattern_id)
+        if not source_code:
+            log(f"  ⚠ Failed to retrieve source for '{pattern_name}'")
+            continue
+
+        try:
+            source_obj = jsonlib.loads(source_code)
+            actual_source = source_obj.get('main', source_code)
+        except Exception:
+            actual_source = source_code
+
+        if not full:
+            actual_source = _strip_js(actual_source)
+
+        click.echo(actual_source)
+
+    if len(matches) > 1:
+        log(f"\n{len(matches)} patterns matched '{path}'")
+
+
+## ─── Filesystem ───────────────────────────────────────────────────────────────
 
 @cli(pixelblaze)
 def ls(pb: Pixelblaze):
@@ -1098,25 +1749,76 @@ def pbb(ctx, output_file, quiet, decode, binary):
 @cli(pixelblaze)
 @click.argument('input_file')
 @click.option('--quiet', '-q', is_flag=True, help='Suppress verbose progress output')
-def restore(pb: Pixelblaze, input_file, quiet):
+@click.option('--name', 'device_name', default=None,
+              help='Override the device name on the target (avoids identity clash)')
+@click.option('--keep-name', is_flag=True,
+              help="Preserve the target device's current name (don't overwrite from backup)")
+@click.option('--keep-config', is_flag=True,
+              help="Skip restoring config files entirely (only restore patterns, playlists, etc.)")
+def restore(pb: Pixelblaze, input_file, quiet, device_name, keep_name, keep_config):
     """
     Restore a Pixelblaze from a Binary Backup (.pbb file).
 
     Restores the entire Pixelblaze configuration from a .pbb backup file,
     including patterns, settings, map data, and all configuration files.
 
+    When cloning a backup to a different Pixelblaze, use --name or
+    --keep-name to avoid identity clashes (both devices having the same
+    name on the network). Use --keep-config to skip config files entirely
+    and only restore patterns and playlists.
+
     WARNING: This will overwrite all current patterns and settings!
 
     \b
     Examples:
-        pb --ip 192.168.1.24 restore backup.pbb
-        pb --ip 192.168.1.24 restore my_config.pbb
+        pb restore backup.pbb                          # Full restore
+        pb restore backup.pbb --name "Living Room 2"   # Restore with new name
+        pb restore backup.pbb --keep-name              # Keep target's current name
+        pb restore backup.pbb --keep-config            # Only restore patterns/playlists
+        pb restore backup.pbb -q                       # Quiet mode
     """
+    check(not (device_name and keep_name), "Cannot use --name and --keep-name together")
+    check(not (device_name and keep_config), "Cannot use --name and --keep-config together (--keep-config skips all config)")
+
     if not input_file.endswith('.pbb'):
         input_file += '.pbb'
 
     log(f"Restoring from {input_file}...")
     backup = PBB.fromFile(input_file)
+
+    if keep_config:
+        # Remove all config files from the backup so they won't be restored
+        # Note: PBB.deleteFile has an upstream bug (looks at top-level instead
+        # of ['files']), so we patch the backup data directly.
+        config_files = backup.getFileList(PBB.fileTypes.fileConfig)
+        if config_files:
+            import json as _json
+            _data = _json.loads(backup._PBB__textData)
+            for f in config_files:
+                if f in _data.get('files', {}):
+                    del _data['files'][f]
+                    log(f"Skipping config file: {f}")
+            backup._PBB__textData = _json.dumps(_data, indent=2)
+    elif keep_name or device_name:
+        # Determine the name to use
+        if keep_name:
+            target_name = pb.getDeviceName()
+            log(f"Preserving target device name: {target_name}")
+        else:
+            target_name = device_name
+            log(f"Overriding device name to: {target_name}")
+
+        # Patch /config.json in the backup with the desired name
+        try:
+            config_bytes = backup.getFile('/config.json')
+            config = jsonlib.loads(config_bytes.decode('utf-8'))
+            old_name = config.get('name', '(unknown)')
+            config['name'] = target_name
+            log(f"Patching config.json: name '{old_name}' → '{target_name}'")
+            backup.putFile('/config.json', jsonlib.dumps(config).encode('utf-8'))
+        except (KeyError, jsonlib.JSONDecodeError) as e:
+            log(f"Warning: could not patch config.json ({e}), restoring as-is")
+
     backup.toPixelblaze(pb, verbose=not quiet)
     log("Restore complete!")
 
@@ -1141,11 +1843,8 @@ def show():
     log("")
 
     # Show IP cache
-    ip_file = cache_dir / 'last_ip.txt'
-    if ip_file.exists():
-        log(f"Cached IP: {ip_file.read_text().strip()}")
-    else:
-        log("Cached IP: (none)")
+    last_ip = _read_cache().get('lastIp')
+    log(f"Cached IP: {last_ip}" if last_ip else "Cached IP: (none)")
 
     # Show compiler cache
     compiler_cache = cache_dir / 'compiler_cache'
@@ -1180,9 +1879,9 @@ def clear(compiler, ip):
         return
 
     if ip:
-        ip_file = cache_dir / 'last_ip.txt'
-        if ip_file.exists():
-            ip_file.unlink()
+        cache = _read_cache()
+        if cache.pop('lastIp', None) is not None:
+            _write_cache(cache)
             log("IP cache cleared")
         else:
             log("No IP cache to clear")
@@ -1279,6 +1978,124 @@ def reboot(ctx, wait):
 
         if not reconnected:
             log("Warning: Timed out waiting for device to reconnect")
+
+
+@pixelblaze.group()
+def cache():
+    """View and refresh the on-disk device cache (no network unless 'refresh')."""
+    pass
+
+
+@cache.command(name='ls')
+@click.option('--json', 'as_json', is_flag=True, help='Output one JSON object per device.')
+def cache_ls(as_json):
+    """List all cached Pixelblazes with summary info. No network calls.
+
+    \b
+    Examples:
+        pb cache ls            # human-readable summary, * marks lastIp
+        pb cache ls --json     # JSONL output for piping into jq
+    """
+    cache_data = _read_cache()
+    devices = cache_data.get('devices', {})
+    last_ip = cache_data.get('lastIp')
+    if not devices:
+        log("No cached devices. Run `pb find` to discover.")
+        return
+    for ip, entry in devices.items():
+        if as_json:
+            click.echo(jsonlib.dumps(entry, separators=(',', ':')))
+            continue
+        marker = '*' if ip == last_ip else ' '
+        name = entry.get('name', '?') or '?'
+        pixels = entry.get('pixelCount', '?')
+        ver = entry.get('ver', '?')
+        active = entry.get('activePatternName') or entry.get('activePatternId') or '-'
+        last_seen = entry.get('lastSeenAt', 'never')
+        click.echo(f"{marker} {ip:15}  {name:20}  {pixels}px  v{ver}  → {active}  @ {last_seen}")
+
+
+@cache.command(name='show')
+@click.argument('query', required=False)
+def cache_show(query):
+    """Show full cached config for a device (no network call).
+
+    QUERY is an IP, a device name, or a name substring. With no QUERY, shows lastIp.
+
+    \b
+    Examples:
+        pb cache show                  # full dump of lastIp's config
+        pb cache show jforb            # lookup by name substring
+        pb cache show 192.168.1.86     # lookup by exact IP
+    """
+    if not query:
+        last_ip = _read_cache().get('lastIp')
+        if not last_ip:
+            raise click.ClickException("No lastIp cached. Specify <ip-or-name> or run `pb find`.")
+        query = last_ip
+    ip, entry = lookup_cached_device(query)
+    click.echo(jsonlib.dumps(entry, indent=2))
+
+
+@cache.command(name='refresh')
+@click.argument('query', required=False)
+@click.option('--all', 'all_devices', is_flag=True, help='Refresh every cached device in parallel.')
+@click.option('--timeout', 'conn_timeout', type=float, default=5.0,
+              help='Per-device connection timeout in seconds.', show_default=True)
+def cache_refresh(query, all_devices, conn_timeout):
+    """Force-refresh cached config from device(s), bypassing TTL. Always fetches patterns.
+
+    \b
+    Examples:
+        pb cache refresh              # refresh lastIp
+        pb cache refresh jforb        # refresh by name substring
+        pb cache refresh --all        # refresh every cached device (parallel)
+    """
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
+    cache_data = _read_cache()
+    devices_cached = cache_data.get('devices', {})
+    if not devices_cached:
+        raise click.ClickException("No cached devices. Run `pb find` first.")
+
+    if all_devices:
+        targets = list(devices_cached.keys())
+    elif query:
+        ip, _ = lookup_cached_device(query)
+        targets = [ip]
+    else:
+        last_ip = cache_data.get('lastIp')
+        if not last_ip:
+            raise click.ClickException("Specify QUERY or --all, or set lastIp via `pb find`.")
+        targets = [last_ip]
+
+    log(f"Refreshing {len(targets)} device(s)...")
+    Pixelblaze.default_recv_timeout = conn_timeout
+
+    def _refresh_one(ip):
+        try:
+            with Pixelblaze(ip) as pb:
+                return _fetch_device_config(pb, ip=ip, include_patterns=True)
+        except Exception as e:
+            log(f"  {ip}: failed ({type(e).__name__}: {e})")
+            return None
+
+    refreshed = []
+    with ThreadPoolExecutor(max_workers=min(len(targets), 8)) as pool:
+        futures = {pool.submit(_refresh_one, ip): ip for ip in targets}
+        for fut in as_completed(futures):
+            r = fut.result()
+            if r:
+                refreshed.append(r)
+                log(f"  {r['ip']}: {r.get('name', '?')} "
+                    f"(v{r.get('ver', '?')}, {r.get('pixelCount', '?')}px, "
+                    f"{len(r.get('patterns', {}))} patterns)")
+
+    if refreshed:
+        update_device_cache(refreshed)
+        log(f"Refreshed {len(refreshed)}/{len(targets)} device(s).")
+    else:
+        raise click.ClickException("Could not refresh any devices.")
 
 
 def main():

--- a/pixelblaze/cli/cli.py
+++ b/pixelblaze/cli/cli.py
@@ -1237,6 +1237,55 @@ def setup(ctx):
     log("WiFi reset to setup mode — look for a 'Pixelblaze_*' network")
 
 
+@cli(wifi)
+def peers(pb: Pixelblaze):
+    """
+    List the sync-group members this Pixelblaze can see, including itself.
+
+    Follower devices don't broadcast LAN beacons, so `pb find` won't see
+    them via the standard discovery path. This command asks the device
+    for its current view of the sync group. The connected device is
+    prepended to the list and marked with `*`.
+
+    \b
+    Examples:
+        pb wifi peers
+        pb wifi peers --ip 192.168.1.230
+    """
+    peers = pb.getPeers()
+
+    # getPeers returns only *other* members, not self — synthesize a self row
+    # from the device's own config so users see the whole group.
+    cfg = pb.getConfigSettings()
+    self_entry = {
+        'id': cfg.get('chipId', 0),
+        'address': pb.ipAddress,
+        'name': cfg.get('name', '?'),
+        'ver': cfg.get('ver', '?'),
+        'isFollowing': 1 if cfg.get('leaderId', 0) else 0,
+        'nodeId': cfg.get('nodeId', 0),
+        'followerCount': sum(1 for p in peers if p.get('isFollowing')),
+        'self': True,
+    }
+    all_members = [self_entry] + peers
+    jsons(all_members)
+
+    log(f"\n    {'NAME':<20} {'ADDRESS':<15} {'CHIPID':>10} {'NODE':>5} {'ROLE':<10} {'VER':<6} {'FOLLOWERS':>9}")
+    log(f"    {'─' * 20} {'─' * 15} {'─' * 10} {'─' * 5} {'─' * 10} {'─' * 6} {'─' * 9}")
+    for p in all_members:
+        role = 'follower' if p.get('isFollowing') else 'leader'
+        marker = '*' if p.get('self') else ' '
+        # Firmware only fills followerCount reliably from the reporting device's
+        # own perspective. From a follower's vantage, a leader peer always
+        # reports 0 — mark that unknown instead of parroting a wrong number.
+        if p.get('self') or p.get('isFollowing'):
+            fc = str(p.get('followerCount', 0))
+        else:
+            fc = '?'
+        log(f"  {marker:<1} {p.get('name', '?'):<20} {p.get('address', '?'):<15} {p.get('id', 0):>10} "
+            f"{p.get('nodeId', 0):>5} {role:<10} {p.get('ver', '?'):<6} {fc:>9}")
+
+
 ## ─── Cat ──────────────────────────────────────────────────────────────────────
 
 def _strip_js(source: str) -> str:

--- a/pixelblaze/cli/cli_utils.py
+++ b/pixelblaze/cli/cli_utils.py
@@ -2,18 +2,26 @@
 
 from __future__ import annotations
 
+import os
 import sys
+import time
 import socket
 import click
 import json5
 import json
 import pathlib
+import datetime
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from functools import wraps
 from typing import Callable, Optional
 from pixelblaze.pixelblaze import Pixelblaze
 
 log = lambda *args, **kwargs: click.echo(*args, err=True, *kwargs)
 jsons = lambda x: click.echo(json.dumps(x, separators=(',', ':')))
+
+# Opportunistic cache refresh: skip if the entry was refreshed less than this many seconds ago.
+# Override with `pb cache refresh` (force) or env PB_CACHE_TTL.
+CACHE_TTL_SECONDS = 60 * 60
 
 
 def get_cache_dir():
@@ -29,24 +37,72 @@ def get_cache_dir():
     return cache_dir
 
 
-def get_cached_ip():
-    """Get the last used IP from cache."""
+def get_host_ip() -> str:
+    """Get the local machine's outbound IP address."""
     try:
-        cache_file = get_cache_dir() / 'last_ip.txt'
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        # Standard trick: connect() a UDP socket to an unroutable address —
+        # no packets are actually sent; the kernel just resolves which local
+        # interface WOULD be used, and getsockname() reports its IP.
+        # 10.255.255.255 is the RFC 919 limited-broadcast address for the
+        # 10.0.0.0/8 private range, so this works even without a default
+        # gateway (e.g. when joined only to a PB's AP-mode SSID).
+        s.connect(('10.255.255.255', 1))
+        ip = s.getsockname()[0]
+        s.close()
+        return ip
+    except Exception:
+        return ''
+
+
+def _read_cache() -> dict:
+    """Read cache.json, returning empty structure on missing/corrupt file."""
+    try:
+        cache_file = get_cache_dir() / 'cache.json'
         if cache_file.exists():
-            return cache_file.read_text().strip()
+            return json.loads(cache_file.read_text())
     except Exception:
         pass
-    return None
+    return {'lastIp': None, 'devices': {}}
+
+
+def _write_cache(cache: dict):
+    """Write cache.json atomically."""
+    try:
+        (get_cache_dir() / 'cache.json').write_text(json.dumps(cache, indent=2))
+    except Exception:
+        pass
+
+
+def update_device_cache(devices: list[dict]):
+    """Merge device info into cache.json devices map, preserving existing richer data."""
+    cache = _read_cache()
+    known = cache.setdefault('devices', {})
+    host_ip = get_host_ip()
+    for dev in devices:
+        ip = dev.get('ip')
+        if not ip:
+            continue
+        entry = known.setdefault(ip, {'ip': ip})
+        for k, v in dev.items():
+            if v is not None and v != '':
+                entry[k] = v
+        if host_ip:
+            entry['hostIp'] = host_ip
+    _write_cache(cache)
+
+
+def get_cached_ip():
+    """Get the last used IP from cache."""
+    cache = _read_cache()
+    return cache.get('lastIp')
 
 
 def cache_ip(ip_address):
     """Cache the IP address for future use."""
-    try:
-        cache_file = get_cache_dir() / 'last_ip.txt'
-        cache_file.write_text(ip_address)
-    except Exception:
-        pass
+    cache = _read_cache()
+    cache['lastIp'] = ip_address
+    _write_cache(cache)
 
 # Reusable Click options
 no_save_option = click.option(
@@ -58,9 +114,229 @@ no_save_option = click.option(
 # Reusable Click arguments
 input_arg = click.argument('input', required=False)
 
+def _check_ip_reachable(ip: str, timeout: float = 1.0) -> bool:
+    """Check if a given IP has port 80 open (quick TCP connect check)."""
+    try:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.settimeout(timeout)
+        result = sock.connect_ex((ip, 80))
+        sock.close()
+        return result == 0
+    except Exception:
+        return False
+
+
+# Top-level keys promoted out of `settings` for quick display in `pb cache ls` / `pb find`.
+_SUMMARY_KEYS = (
+    'name', 'brandName', 'ver', 'pixelCount', 'ledType', 'dataSpeed',
+    'colorOrder', 'brightness', 'maxBrightness', 'cpuSpeed',
+    'networkPowerSave', 'sensorInputSource', 'discoveryEnable', 'timezone',
+)
+
+
+def _fetch_device_config(pb: Pixelblaze, ip: str, include_patterns: bool = True) -> dict:
+    """Fetch full basic config from a connected Pixelblaze.
+
+    Each sub-call is wrapped so a partial failure still persists what we got.
+    `include_patterns=False` skips the heavier getPatternList() call (the existing
+    cached pattern list, if any, is preserved by update_device_cache's merge).
+    """
+    info = {'ip': ip}
+
+    # getConfigSettings primes pb.latestSequencer, so getConfigSequencer below is ~free.
+    try:
+        settings = pb.getConfigSettings()
+        for key in _SUMMARY_KEYS:
+            if key in settings:
+                info[key] = settings[key]
+        info['settings'] = settings
+    except Exception as e:
+        info['settingsError'] = str(e)
+
+    try:
+        seq = pb.getConfigSequencer()
+        info['sequencer'] = seq
+        active = seq.get('activeProgram', {}) if isinstance(seq, dict) else {}
+        info['activePatternId'] = active.get('activeProgramId', '') or ''
+    except Exception as e:
+        info['sequencerError'] = str(e)
+
+    if include_patterns:
+        try:
+            patterns = pb.getPatternList()
+            info['patterns'] = patterns
+            active_id = info.get('activePatternId', '')
+            if active_id and active_id in patterns:
+                info['activePatternName'] = patterns[active_id]
+        except Exception as e:
+            info['patternsError'] = str(e)
+
+    info['lastSeenAt'] = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    return info
+
+
+def _get_device_info(ip: str) -> dict:
+    """Connect to a Pixelblaze and return a full device info dict (parallel-safe)."""
+    try:
+        with Pixelblaze(ip) as pb:
+            return _fetch_device_config(pb, ip=ip, include_patterns=True)
+    except Exception:
+        return {'ip': ip, 'name': ''}
+
+
+def _cache_is_fresh(ip: str, ttl_seconds: int = CACHE_TTL_SECONDS) -> bool:
+    """Return True if cache entry for ip exists, has a config snapshot, and is within ttl."""
+    entry = _read_cache().get('devices', {}).get(ip)
+    if not entry or 'settings' not in entry:
+        return False
+    last_seen = entry.get('lastSeenAt')
+    if not last_seen:
+        return False
+    try:
+        dt = datetime.datetime.fromisoformat(last_seen)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=datetime.timezone.utc)
+        age = (datetime.datetime.now(datetime.timezone.utc) - dt).total_seconds()
+        return age < ttl_seconds
+    except Exception:
+        return False
+
+
+def maybe_refresh_cache(pb: Pixelblaze, ip: str, force: bool = False) -> bool:
+    """Opportunistically refresh cached config for `ip` using an already-connected pb.
+
+    Silent on any failure. Returns True if a refresh was attempted.
+    Skips the patternList fetch on routine refreshes (when patterns are already cached)
+    to keep the post-command cost minimal; `force=True` always re-fetches everything.
+    """
+    try:
+        if not ip:
+            return False
+        if not force and _cache_is_fresh(ip):
+            return False
+        existing = _read_cache().get('devices', {}).get(ip, {})
+        include_patterns = force or 'patterns' not in existing
+        info = _fetch_device_config(pb, ip=ip, include_patterns=include_patterns)
+        update_device_cache([info])
+        return True
+    except Exception:
+        return False
+
+
+def lookup_cached_device(query: str) -> tuple[str, dict]:
+    """Look up a cached device by exact IP or case-insensitive name substring.
+
+    Raises click.ClickException if not found or ambiguous.
+    """
+    devices = _read_cache().get('devices', {})
+    if not devices:
+        raise click.ClickException("No cached devices. Run `pb find` first.")
+    if query in devices:
+        return query, devices[query]
+    q = query.lower()
+    matches = [(ip, e) for ip, e in devices.items() if q in (e.get('name') or '').lower()]
+    if len(matches) == 1:
+        return matches[0]
+    if len(matches) > 1:
+        names = ', '.join(f"{e.get('name', '?')} ({ip})" for ip, e in matches)
+        raise click.ClickException(f"Ambiguous query '{query}': matches {names}")
+    raise click.ClickException(f"No cached device matches '{query}'.")
+
+
+def _discover_ips(timeout: int = 2000) -> list[str]:
+    """
+    Discover Pixelblaze IP addresses via ad-hoc check and UDP beacons.
+
+    Fast — no websocket connections, just network probing.
+
+    Args:
+        timeout: Beacon listen timeout in milliseconds.
+
+    Returns:
+        list[str]: List of discovered IP addresses.
+    """
+    ips = []
+    seen = set()
+
+    # Check ad-hoc mode first
+    adhoc_ip = "192.168.4.1"
+    log(f"Checking ad-hoc ({adhoc_ip})...")
+    if _check_ip_reachable(adhoc_ip):
+        ips.append(adhoc_ip)
+        seen.add(adhoc_ip)
+        log(f"  Found @ {adhoc_ip} (ad-hoc)")
+
+    # Beacon enumeration
+    log(f"Listening for beacons ({timeout}ms)...")
+    try:
+        for found_ip in Pixelblaze.EnumerateAddresses(timeout=timeout):
+            if found_ip not in seen:
+                seen.add(found_ip)
+                ips.append(found_ip)
+                log(f"  Found @ {found_ip}")
+    except Exception as e:
+        log(f"Enumeration error: {e}")
+
+    return ips
+
+
+def enumerate_pixelblazes(timeout: int = 3000, slow: bool = False) -> list[dict]:
+    """
+    Discover all Pixelblazes on the network.
+
+    In fast mode (default), returns minimal dicts with just the IP from
+    beacon discovery. In slow mode, connects to each device in parallel
+    to fetch name, config, version, etc.
+
+    Args:
+        timeout: Beacon listen timeout in milliseconds.
+        slow: If True, connect to each device to fetch full config info.
+
+    Returns:
+        list[dict]: Device info dicts. Fast mode: {'ip': ...} only.
+                    Slow mode adds: name, pixelCount, brightness, ver, brandName, hostIp.
+    """
+    ips = _discover_ips(timeout=timeout)
+
+    if not ips:
+        return []
+
+    host_ip = get_host_ip()
+
+    if not slow:
+        devices = [{'ip': ip} for ip in ips]
+        update_device_cache(devices)
+        return devices
+
+    # Slow mode: connect to each device to get full info, in parallel
+    log(f"Fetching device info from {len(ips)} device(s)...")
+    devices = []
+    with ThreadPoolExecutor(max_workers=min(len(ips), 8)) as pool:
+        futures = {pool.submit(_get_device_info, ip): ip for ip in ips}
+        for future in as_completed(futures):
+            info = future.result()
+            if info:
+                if host_ip:
+                    info['hostIp'] = host_ip
+                devices.append(info)
+                name = info.get('name', '?')
+                if name:
+                    log(f"  {info['ip']}: {name}")
+
+    # Preserve discovery order
+    ip_order = {ip: i for i, ip in enumerate(ips)}
+    devices.sort(key=lambda d: ip_order.get(d['ip'], 999))
+
+    update_device_cache(devices)
+    return devices
+
+
 def discover_pixelblaze(ctx: click.Context) -> str:
     """
     Discovers a Pixelblaze IP address using the specified strategy.
+
+    Uses cached IP, ad-hoc check, then beacon enumeration. Returns the
+    first reachable IP and caches it.
 
     Args:
         ctx: Click context containing IP address in ctx.obj['ip']
@@ -78,49 +354,20 @@ def discover_pixelblaze(ctx: click.Context) -> str:
         return ip_address
 
     # Try cached IP first
-    cached_ip = get_cached_ip()
-    if cached_ip:
-        click.echo(f"Trying cached IP {cached_ip}...", err=True)
-        try:
-            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            sock.settimeout(1)
-            result = sock.connect_ex((cached_ip, 80))
-            sock.close()
+    cached = get_cached_ip()
+    if cached:
+        log(f"Trying cached IP {cached}...")
+        if _check_ip_reachable(cached):
+            log(f"Found Pixelblaze at {cached} (cached)")
+            return cached
+        log(f"Cached IP {cached} not responding, searching...")
 
-            if result == 0:
-                click.echo(f"Found Pixelblaze at {cached_ip} (cached)", err=True)
-                return cached_ip
-        except Exception:
-            pass
-        click.echo(f"Cached IP {cached_ip} not responding, searching...", err=True)
-
-    # Try ad-hoc mode first (192.168.4.1)
-    adhoc_ip = "192.168.4.1"
-    click.echo(f"Checking for Pixelblaze in ad-hoc mode at {adhoc_ip}...", err=True)
-
-    try:
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.settimeout(1)
-        result = sock.connect_ex((adhoc_ip, 80))
-        sock.close()
-
-        if result == 0:
-            click.echo(f"Found Pixelblaze at {adhoc_ip}", err=True)
-            cache_ip(adhoc_ip)
-            return adhoc_ip
-    except Exception as e:
-        click.echo(f"Ad-hoc check failed: {e}", err=True)
-
-    # Fall back to enumerator
-    click.echo("Searching for Pixelblazes on network...", err=True)
-
-    try:
-        for found_ip in Pixelblaze.EnumerateAddresses(timeout=2000):
-            click.echo(f"Found Pixelblaze at {found_ip}", err=True)
-            cache_ip(found_ip)
-            return found_ip
-    except Exception as e:
-        click.echo(f"Enumeration failed: {e}", err=True)
+    # Full enumeration — return first found (fast, no websocket connects)
+    ips = _discover_ips(timeout=2000)
+    if ips:
+        update_device_cache([{'ip': ip} for ip in ips])
+        cache_ip(ips[0])
+        return ips[0]
 
     raise click.ClickException(
         "No Pixelblaze found. Specify an IP address with --ip or ensure a Pixelblaze is on the network."
@@ -147,16 +394,7 @@ def read_input(value: Optional[str], name: str = "input", required: bool = True,
     Raises:
         click.ClickException: If no input provided and required=True
     """
-    import os
-
-    # Check stdin first if it's piped (not a TTY)
-    if not sys.stdin.isatty():
-        if binary:
-            return (sys.stdin.buffer.read(), True)
-        else:
-            return (sys.stdin.read().strip(), True)
-
-    # No stdin, check value
+    # If an explicit value was provided, check file path first (before stdin)
     if value is not None:
         # Check if it's an existing file path
         if os.path.isfile(value):
@@ -170,6 +408,13 @@ def read_input(value: Optional[str], name: str = "input", required: bool = True,
                 f"Cannot use inline content in binary mode. Provide a file path or pipe via stdin."
             )
         return (value, False)
+
+    # No explicit value — check stdin if it's piped (not a TTY)
+    if not sys.stdin.isatty():
+        if binary:
+            return (sys.stdin.buffer.read(), True)
+        else:
+            return (sys.stdin.read().strip(), True)
 
     # No stdin, no value
     if required:
@@ -299,9 +544,48 @@ def get_pixelblaze(ctx: click.Context) -> Pixelblaze:
     """
     discovered_ip = discover_pixelblaze(ctx)
     ctx.obj['ip'] = discovered_ip  # Update with actual IP used
+    timeout = ctx.obj.get('timeout', 5.0)
+    Pixelblaze.default_recv_timeout = timeout
     pb = Pixelblaze(discovered_ip)
     ctx.obj['pixelblaze'] = pb
     return pb
+
+
+
+# Transient errors that warrant a retry
+_RETRYABLE = (
+    ConnectionError,
+    ConnectionResetError,
+    TimeoutError,
+    OSError,
+)
+
+try:
+    import websocket
+    _RETRYABLE = _RETRYABLE + (websocket._exceptions.WebSocketTimeoutException,
+                                websocket._exceptions.WebSocketConnectionClosedException,)
+except Exception:
+    pass
+
+try:
+    import requests as _req
+    _RETRYABLE = _RETRYABLE + (_req.ConnectionError, _req.Timeout,)
+except Exception:
+    pass
+
+
+def _run_with_retries(ctx: click.Context, fn, *args, **kwargs):
+    """Run fn with retry logic on transient connection errors."""
+    max_retries = ctx.obj.get('retries', 3)
+    for attempt in range(max_retries + 1):
+        try:
+            return fn(*args, **kwargs)
+        except _RETRYABLE as e:
+            if attempt >= max_retries:
+                raise
+            delay = 0.5 * (attempt + 1)
+            log(f"Connection error ({type(e).__name__}), retry {attempt + 1}/{max_retries} in {delay:.1f}s...")
+            time.sleep(delay)
 
 
 def cli(cli_group, conn=True, **click_kwargs) -> Callable:
@@ -311,6 +595,9 @@ def cli(cli_group, conn=True, **click_kwargs) -> Callable:
     Returns a decorator that combines @click.command() and @click.pass_context functionality,
     automatically injecting a connected Pixelblaze instance as the first argument
     and wrapping the function body in a context manager.
+
+    Automatically retries on transient connection errors (ConnectionResetError,
+    timeouts, etc.) using the --retries global option.
 
     Usage:
         @cli(pixelblaze)
@@ -336,13 +623,15 @@ def cli(cli_group, conn=True, **click_kwargs) -> Callable:
     def decorator(func: Callable) -> Callable:
         @wraps(func)
         def wrapper(ctx: click.Context, *args, **kwargs):
-            if conn:
-                # Default behavior: connect and pass pb
-                with get_pixelblaze(ctx) as pb:
-                    return func(pb, *args, **kwargs)
-            else:
-                # Pass context, let function handle connection
-                return func(ctx, *args, **kwargs)
+            def _run():
+                if conn:
+                    with get_pixelblaze(ctx) as pb:
+                        result = func(pb, *args, **kwargs)
+                        maybe_refresh_cache(pb, ctx.obj.get('ip', ''))
+                        return result
+                else:
+                    return func(ctx, *args, **kwargs)
+            return _run_with_retries(ctx, _run)
 
         # Apply click.pass_context and cli.command() decorators
         wrapper = click.pass_context(wrapper)

--- a/pixelblaze/cli/cli_utils.py
+++ b/pixelblaze/cli/cli_utils.py
@@ -277,6 +277,21 @@ def _discover_ips(timeout: int = 2000) -> list[str]:
     except Exception as e:
         log(f"Enumeration error: {e}")
 
+    # Follower enrichment — follower devices don't broadcast beacons, but any
+    # beacon-visible peer knows about them via the sync group. Ask each for
+    # its peer list and union in anything new.
+    for ip in list(ips):
+        try:
+            with Pixelblaze(ip) as pb:
+                for peer in pb.getPeers():
+                    peer_ip = peer.get('address')
+                    if peer_ip and peer_ip not in seen:
+                        seen.add(peer_ip)
+                        ips.append(peer_ip)
+                        log(f"  Found @ {peer_ip} (via {ip} sync group)")
+        except Exception as e:
+            log(f"  Peer query failed on {ip}: {e}")
+
     return ips
 
 

--- a/pixelblaze/pixelblaze.py
+++ b/pixelblaze/pixelblaze.py
@@ -759,14 +759,30 @@ class Pixelblaze:
             self.ws.send_binary(bytes(frameHeader) + payload[i:i + maxFrameSize])
             time.sleep(sleepTime)
 
-    def getPeers(self):
-        """A new command, added to the API but not yet implemented as of v2.29/v3.24, that will return a list of all the Pixelblazes visible on the local network segment.
+    def getPeers(self) -> list[dict]:
+        """Returns the sync-group peers this Pixelblaze is aware of.
+
+        In group-sync (leader/follower) setups, follower devices do not
+        broadcast LAN beacons on UDP:1889 — so `EnumerateAddresses` misses
+        them. `getPeers` asks the Pixelblaze for its current view of the
+        sync group, which the firmware maintains via peer-to-peer discovery.
+
+        Confirmed working on firmware v3.51.
 
         Returns:
-            TBD: To be defined once @wizard implements the function.
+            list[dict]: One entry per peer, empty list if no peers. Each entry:
+                id (int): chipId of the peer.
+                address (str): IPv4 address.
+                name (str): device name.
+                ver (str): firmware version.
+                isFollowing (int): 1 if this peer is a follower, 0 if leader/solo.
+                nodeId (int): sync-group node id.
+                followerCount (int): number of followers this peer has.
         """
-        self.wsSendJson({"getPeers": True})
-        return self.wsReceive(binaryMessageType=None)
+        response = self.wsSendJson({"getPeers": True}, expectedResponse="peers")
+        if response is None:
+            return []
+        return json.loads(response).get("peers", [])
 
     # --- PIXELBLAZE FILESYSTEM FUNCTIONS:
 

--- a/pixelblaze/pixelblaze.py
+++ b/pixelblaze/pixelblaze.py
@@ -1122,15 +1122,19 @@ class Pixelblaze:
         """
         return json.loads(self.wsSendJson({"getPlaylist": playlistId}, expectedResponse="playlist"))
 
-    def setSequencerPlaylist(self, playlistContents: dict, playlistId: str = "_defaultplaylist_"):
+    def setSequencerPlaylist(self, playlistContents: dict, playlistId: str = "_defaultplaylist_", *, saveToFlash: bool = False):
         """Replaces the entire contents of the specified playlist.  At the moment, only the default playlist is supported by the Pixelblaze.
 
         Args:
             playlistContents (dict): The new playlist contents.
             playlistId (str, optional): The name of the playlist (for future enhancement; currently only '_defaultplaylist_' is supported). Defaults to "_defaultplaylist_".
+            saveToFlash (bool, optional): If True, adds an outer `save: true` so the firmware writes the playlist to `/l/<playlistId>` (persists across reboots). Defaults to False (RAM-only — lost on reboot).
         """
         self.latestSequencer = None  # clear cache to force refresh
-        ignored = self.wsSendJson(playlistContents, expectedResponse=None)
+        payload = dict(playlistContents)
+        if saveToFlash:
+            payload['save'] = True
+        ignored = self.wsSendJson(payload, expectedResponse=None)
 
     def addToSequencerPlaylist(self, playlistContents: dict, *, patternId: str, duration: int) -> dict:
         """Appends a new entry to the specified playlist.
@@ -2249,6 +2253,95 @@ class Pixelblaze:
         if configSettings is None: configSettings = self.getConfigSettings()
         return configSettings.get('networkPowerSave', False)
 
+    # --- SETTINGS menu: WIFI settings (HTTP-only, no WebSocket required)
+
+    class wifiModes(IntEnum):
+        """WiFi operating modes reported by the Pixelblaze."""
+        modeClient = 3
+        modeAccessPoint = 6
+        modeSetup = 255
+
+    @staticmethod
+    def getWifiStatus(ipAddress: str, timeout: float = 5.0) -> dict:
+        """Returns the current WiFi status of the Pixelblaze.
+
+        This is an HTTP-only call that works even in ad-hoc/setup mode without a WebSocket connection.
+
+        Args:
+            ipAddress (str): The IP address of the Pixelblaze.
+            timeout (float): Request timeout in seconds. Defaults to 5.0.
+
+        Returns:
+            dict: WiFi status with keys: status (int), ip (str), ssid (str), mac (str).
+        """
+        response = requests.get(f"http://{ipAddress}/wifistatus", timeout=timeout)
+        response.raise_for_status()
+        return response.json()
+
+    @staticmethod
+    def getWifiScan(ipAddress: str, timeout: float = 15.0, poll_interval: float = 1.0) -> list[dict]:
+        """Scans for available WiFi access points.
+
+        This is an HTTP-only call that works even in ad-hoc/setup mode without a WebSocket connection.
+        Polls until the scan completes.
+
+        Args:
+            ipAddress (str): The IP address of the Pixelblaze.
+            timeout (float): Maximum time to wait for scan results in seconds. Defaults to 15.0.
+            poll_interval (float): Time between poll attempts in seconds. Defaults to 1.0.
+
+        Returns:
+            list[dict]: List of access points, each with keys: rssi (int), ssid (str), bssid (str), channel (int), secure (bool).
+        """
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            response = requests.get(f"http://{ipAddress}/wifiscan", timeout=5.0)
+            response.raise_for_status()
+            result = response.json()
+            if isinstance(result, list):
+                return result
+            # Still scanning — {"scanning": 1}
+            time.sleep(poll_interval)
+        return []
+
+    @staticmethod
+    def setWifiConfig(ipAddress: str, mode: str, ssid: str = "", passphrase: str = "", discover: bool = True, timeout: float = 5.0) -> dict:
+        """Sets the WiFi configuration on the Pixelblaze.
+
+        This is an HTTP-only call that works even in ad-hoc/setup mode without a WebSocket connection.
+
+        Args:
+            ipAddress (str): The IP address of the Pixelblaze.
+            mode (str): WiFi mode — "CLIENT", "AP", or "SETUP".
+            ssid (str): The SSID of the network to join or create. Defaults to "".
+            passphrase (str): The password for the network. Defaults to "".
+            discover (bool): Whether to enable Electromage discovery. Defaults to True.
+            timeout (float): Request timeout in seconds. Defaults to 5.0.
+
+        Returns:
+            dict: Response from the Pixelblaze, typically {"ack": 1}.
+        """
+        payload = {
+            "mode": mode,
+            "ssid": ssid,
+            "passphrase": passphrase,
+            "discover": "true" if discover else "false",
+        }
+        response = requests.post(
+            f"http://{ipAddress}/wifisave",
+            data=payload,
+            headers={"Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"},
+            timeout=timeout,
+        )
+        if response.status_code == 400:
+            # Return the raw response for debugging
+            raise requests.HTTPError(
+                f"400 Bad Request from /wifisave (body: {response.text!r})",
+                response=response,
+            )
+        response.raise_for_status()
+        return response.json()
+
     # --- SETTINGS menu: UPDATES settings
 
     class updateStates(IntEnum):
@@ -3134,7 +3227,23 @@ class PBP:
         # Send via WebSocket using Packet Type 1 (putSourceCode / SAVEPROGRAMSOURCEFILE)
         # The firmware expects: patternId (17 bytes) + binary blob
         payload = self.__id.encode('utf-8') + self.__binaryData
-        pb.wsSendBinary(pb.messageTypes.putSourceCode, payload, expectedResponse="ack")
+
+        # Pattern binary sending was often failing until this method of
+        # fire-and-forget with 20ms inter-chunk delay, no per-chunk ack waiting:
+        maxFrameSize = 1280
+        for i in range(0, len(payload), maxFrameSize):
+            frameHeader = bytearray(2)
+            frameHeader[0] = pb.messageTypes.putSourceCode.value  # 1
+            flags = 0
+            if i == 0:
+                flags |= 1  # START
+            if (len(payload) - i) > maxFrameSize:
+                flags |= 2  # CONTINUE
+            else:
+                flags |= 4  # END
+            frameHeader[1] = flags
+            pb.ws.send_binary(bytes(frameHeader) + payload[i:i + maxFrameSize])
+            time.sleep(0.02)
 
     def toEPE(
             self) -> 'EPE':  # 'Quoted' to defer resolution of forward reference; or could use 'from __future__ import annotations'

--- a/pixelblaze/pixelblaze.py
+++ b/pixelblaze/pixelblaze.py
@@ -731,6 +731,34 @@ class Pixelblaze:
                 self._open()
                 # raise
 
+    def wsSendBinaryChunked(self, binaryMessageType: messageTypes, payload: bytes, *, maxFrameSize: int = 1280, sleepTime: float = 0.02):
+        """Fire-and-forget chunked binary send with no per-chunk ack wait.
+
+        Sibling of `wsSendBinary` for message types where waiting on a
+        per-chunk response is unreliable (e.g. `putSourceCode`). Builds the
+        2-byte frame header internally, filling byte 1 with the continuation
+        flags for each chunk.
+
+        Args:
+            binaryMessageType (messageTypes): The binary message type to send.
+            payload (bytes): The body to send, split at `maxFrameSize`.
+            maxFrameSize (int, optional): Chunk size in bytes. Defaults to 1280.
+            sleepTime (float, optional): Delay between chunks in seconds. Defaults to 0.02.
+        """
+        frameHeader = bytearray(2)
+        frameHeader[0] = binaryMessageType.value
+        for i in range(0, len(payload), maxFrameSize):
+            flags = self.frameTypes.frameNone
+            if i == 0:
+                flags |= self.frameTypes.frameFirst
+            if (len(payload) - i) > maxFrameSize:
+                flags |= self.frameTypes.frameMiddle
+            else:
+                flags |= self.frameTypes.frameLast
+            frameHeader[1] = flags.value
+            self.ws.send_binary(bytes(frameHeader) + payload[i:i + maxFrameSize])
+            time.sleep(sleepTime)
+
     def getPeers(self):
         """A new command, added to the API but not yet implemented as of v2.29/v3.24, that will return a list of all the Pixelblazes visible on the local network segment.
 
@@ -3228,22 +3256,9 @@ class PBP:
         # The firmware expects: patternId (17 bytes) + binary blob
         payload = self.__id.encode('utf-8') + self.__binaryData
 
-        # Pattern binary sending was often failing until this method of
-        # fire-and-forget with 20ms inter-chunk delay, no per-chunk ack waiting:
-        maxFrameSize = 1280
-        for i in range(0, len(payload), maxFrameSize):
-            frameHeader = bytearray(2)
-            frameHeader[0] = pb.messageTypes.putSourceCode.value  # 1
-            flags = 0
-            if i == 0:
-                flags |= 1  # START
-            if (len(payload) - i) > maxFrameSize:
-                flags |= 2  # CONTINUE
-            else:
-                flags |= 4  # END
-            frameHeader[1] = flags
-            pb.ws.send_binary(bytes(frameHeader) + payload[i:i + maxFrameSize])
-            time.sleep(0.02)
+        # Pattern binary sending was often failing until we switched to
+        # fire-and-forget chunked send with no per-chunk ack waiting.
+        pb.wsSendBinaryChunked(pb.messageTypes.putSourceCode, payload)
 
     def toEPE(
             self) -> 'EPE':  # 'Quoted' to defer resolution of forward reference; or could use 'from __future__ import annotations'


### PR DESCRIPTION
## Summary

Expands the Python API and grows the `pb` CLI  covering config, playlist, wifi, patterns, filesystem, and backup ops.

### API additions (`pixelblaze.py`)

* **Wifi** (uses stock HTTP-only, works in AP/setup mode without a websocket, get and set):
  `wifiModes` IntEnum (`modeClient` = 3, `modeAccessPoint` = 6, `modeSetup` = 255) +
  `getWifiStatus`, `getWifiScan`, `setWifiConfig`.
* **Playlist persistence fix**: `setSequencerPlaylist(..., *, saveToFlash=False)` —
  the outer `save: true` the firmware requires to write `/l/<id>` was missing,
  so playlist changes were lost on reboot. Kwarg-only, default off (backwards compatible).
* **Pattern I/O**: `savePattern()` end-to-end working with frame-size / chunking fixes;
  `compilePattern()` uses `lzstring` for compression; pattern-list caching layer with
  configurable refresh interval; new `getPatternSourceCode`.
* **Chunking helper**: `wsSendBinaryChunked(binaryMessageType, payload, *, maxFrameSize=1280, sleepTime=0.02)` —
  sibling of `wsSendBinary` for fire-and-forget sends (e.g. `putSourceCode`).
  Extracted from the inlined loop in `PBP.toPixelblaze()`.
* **Sync-group discovery**: `getPeers()` now returns parsed `list[dict]` of sync-group
  members (`id`, `address`, `name`, `ver`, `isFollowing`, `nodeId`, `followerCount`).
  Firmware v3.51 (and probably older) implements the endpoint; the previous library stub was TBD/unparsed.

### CLI (`pb`)

* General: Improved caching and discovery of PixelBlaze devices features, as well as auto retries
   for recoverable network glitches. Add map clear ability. Fix bug where pixels were stuck if
   decreasing pixel count.
* `pb cfg` — unified getter/setter for the Settings-page fields. Getter dumps
  `{config, wifi, patterns, playlist, sequencer}` JSON. Setter accepts flags
  including `--pixels`, `--color-order`, `--brightness`, `--led-type`,
  `--cpu`, `--discovery`, `--timezone`, `--auto-off*`, `--leader-id`,
  `--node-id`. Multi-key sets bundle into one wsSendJson so they commit atomically.
* `pb playlist` group: `pause | play | next | rand | len | set`. `set` builds
  a playlist from a CSV of case-insensitive pattern-name searches AND/or local
  `.js` file paths (uploaded if not on the device); supports `--shuffle` and
  `-d SECONDS`. Renamed to clearer `playlist` from "seq".
* `pb wifi status | scan | join | ap | peers` — get and set wifi options, uses HTTP-only endpoints.
  `peers` lists sync-group members the device can see; prepends self (marked `*`) and
  shows leader-peer `followerCount` as `?` when it isn't reliably inferrable from the current vantage.
* `pb find` — after beacon discovery, also unions in sync-group members via `getPeers`,
  so followers (which don't broadcast beacons) are found.
* `pb pattern` — unified switch / render / save / rm / cat / lookup.
* `pb pbb` / `pb restore` — binary backup (`.pbb`) round-trip.
* `pb cp` / `pb ls` / `pb cat` — filesystem ops with stdin/stdout streaming.
* `pb ws` — raw websocket request/response with configurable `--expect`.
* `pb cache` — inspect/clear the on-disk device cache.
* `pb reboot [--wait]`, `pb ping`, `pb pixels`, `pb on`/`off`, `pb var`, `pb map`.

Also updates `examples/cli_examples.sh` to cover the new subcommands.

## Test plan

- [x] Manual smoke against a live V3 (leader in AP mode + client follower)
- [x] Playlist persistence verified across reboot after the `setSequencerPlaylist` fix
- [x] `pb wifi status` returns SSID / IP / MAC / mode against a real device
- [x] `pb playlist set '…' --shuffle` writes and starts a mixed name-and-file playlist
- [x] `pb cfg` round-trip: read → set multiple keys → verify each landed
- [x] `pb wifi peers` from leader and follower both show correct self + peers rows
- [x] `pb find` sees a beacon-silent follower via its leader's sync group
