### PR TITLE
API + CLI: pb update — offline firmware .stfu upload with progress

### DIFF
--- a/pixelblaze/cli/cli.py
+++ b/pixelblaze/cli/cli.py
@@ -25,6 +25,7 @@ import time
 import re
 import click
 import pathlib
+from tqdm import tqdm
 from pixelblaze.pixelblaze import Pixelblaze, PBB
 from pixelblaze.cli.cli_utils import cli, log, no_save_option, input_arg, read_input, parse_json, jsons, \
                                      get_cache_dir, check, parse_vars, get_pixelblaze, discover_pixelblaze
@@ -1279,6 +1280,97 @@ def reboot(ctx, wait):
 
         if not reconnected:
             log("Warning: Timed out waiting for device to reconnect")
+
+
+@cli(pixelblaze, conn=False)
+@click.argument('file', type=click.Path(exists=True, dir_okay=False, resolve_path=True))
+@click.option('--timeout', type=float, default=300.0, show_default=True,
+              help='HTTP timeout in seconds (whole flash + response)')
+@click.option('--chunk', type=int, default=8192, show_default=True,
+              help='Progress-tick chunk size in bytes')
+@click.option('--no-ver', is_flag=True,
+              help="Skip querying the device's current firmware version before flashing")
+@click.option('--no-monitor', is_flag=True,
+              help='Fire the upload single-shot; no progress bar, no device polling, no heuristics')
+def update(ctx, file, timeout, chunk, no_ver, no_monitor):
+    """
+    Flash a Pixelblaze firmware `.stfu` file directly to the device.
+
+    Mirrors the built-in recovery.html /update flow — the fully-offline path.
+    Works when the device is reachable via HTTP (regular WiFi or SoftAP at
+    192.168.4.1) but the online updater can't reach ElectroMage's servers,
+    or when the WebSocket API is unresponsive.
+
+    Under monitored mode (default), streams the upload in chunks, polls the
+    device's `upgradeState` on the WebSocket in parallel, and combines the two
+    signals with sane heuristics to judge success. `--no-monitor` skips all of
+    that and just fires a single POST.
+
+    \b
+    Examples:
+        pb update ~/Downloads/v3.70.pb32.stfu
+        pb --ip 192.168.4.1 update firmware.stfu
+        pb update firmware.stfu --no-monitor    # fire and wait silently
+    """
+    device_ip = discover_pixelblaze(ctx)
+    path = pathlib.Path(file)
+    size = path.stat().st_size
+
+    log(f"Uploading {path.name} ({tqdm.format_sizeof(size, 'B', 1000)}) → http://{device_ip}/update")
+    log("Device stays silent until flash completes (~30-60s). Do not power-cycle.")
+
+    # ignoreOpenFailure=True: the device may not have a live WebSocket in recovery mode.
+    pb = Pixelblaze(device_ip, ignoreOpenFailure=True)
+
+    if not no_ver:
+        try:
+            log(f"Current firmware: v{pb.getVersion()}")
+        except Exception as e:
+            log(f"Could not read current firmware version ({type(e).__name__}); continuing anyway")
+
+    try:
+        if no_monitor:
+            ok = pb.installFirmwareFile(str(path), monitor=False,
+                                        chunkSize=chunk, timeout=timeout)
+        else:
+            bar_state = {'bar': None, 'last': 0}
+
+            def on_event(evt):
+                t = evt.get('type')
+                bar = bar_state.get('bar')
+                if t == 'start':
+                    bar_state['bar'] = tqdm(
+                        total=evt['total'], desc='Uploading',
+                        unit='B', unit_scale=True, unit_divisor=1000,
+                        bar_format='{l_bar}{bar}| {n_fmt}/{total_fmt} '
+                                   '[{elapsed}<{remaining}, {rate_fmt}]',
+                    )
+                elif t == 'chunk' and bar is not None:
+                    sent = evt['sent']
+                    bar.update(sent - bar_state['last'])
+                    bar_state['last'] = sent
+                elif t == 'device':
+                    parsed = evt.get('parsed') or {}
+                    if parsed.get('phase') == 'file':
+                        pretty = (f"file {parsed['fileIndex']}/{parsed['fileCount']}, "
+                                  f"{tqdm.format_sizeof(parsed['bytesRemain'], 'B', 1000)} remain")
+                    elif parsed.get('phase') == 'starting':
+                        pretty = 'starting'
+                    else:
+                        pretty = evt.get('progress') or ''
+                    # tqdm.write cooperates with the live bar; keep line above it.
+                    tqdm.write(f"[device] state={evt['code']} {pretty}".rstrip())
+                elif t == 'result' and bar is not None:
+                    bar.close()
+                    bar_state['bar'] = None
+
+            ok = pb.installFirmwareFile(str(path), monitor=True, callback=on_event,
+                                        chunkSize=chunk, timeout=timeout)
+    except Exception as e:
+        raise click.ClickException(f"Firmware upload failed: {e}")
+
+    check(ok, "Device rejected the firmware (wrong variant, corrupted file, or flash error)")
+    log("Firmware accepted. Device is rebooting; it may take 30-60s to reappear on WiFi.")
 
 
 def main():

--- a/pixelblaze/pixelblaze.py
+++ b/pixelblaze/pixelblaze.py
@@ -178,7 +178,7 @@ class Pixelblaze:
 
     ***UPDATES section***
 
-    - [`getUpdateState`](#method-getUpdateState)/[`installUpdate`](#method-installUpdate)
+    - [`getUpdateState`](#method-getUpdateState)/[`installUpdate`](#method-installUpdate)/[`installFirmwareFile`](#method-installFirmwareFile)
     - [`getVersion`](#method-getVersion)/[`getVersionMajor`](#method-getVersionMajor)/[`getVersionMinor`](#method-getVersionMinor)/
 
     ***BACKUPS section***
@@ -2259,6 +2259,7 @@ class Pixelblaze:
         upToDate = 4
         updateAvailable = 5
         updateComplete = 6
+        inProgressAlt = 7  # observed alongside inProgress during OTA writes; treat as in-progress
 
     def getUpdateState(self) -> updateStates:
         """Returns the updateState of the Pixelblaze.
@@ -2298,6 +2299,280 @@ class Pixelblaze:
             print(f"updateProgress: {self.updateStates(state).name}")
             time.sleep(0.5)
         return state
+
+    def installFirmwareFile(self, filePath: str, *, monitor: bool = True, callback=None,
+                            chunkSize: int = 8192, timeout: float = 300.0,
+                            postUploadPollSeconds: float = 5.0,
+                            minUploadSeconds: float = 20.0) -> bool:
+        """Uploads a local firmware `.stfu` file directly to the device's /update endpoint.
+
+        Mirrors the built-in recovery.html flow (a multipart/form-data POST with field
+        name `update`). Useful for offline recovery when the device is reachable via
+        HTTP (its regular IP or SoftAP at 192.168.4.1) but the online updater can't
+        reach ElectroMage's servers, or when the WebSocket API is unresponsive.
+
+        When `monitor` is True (default), streams the upload in chunks and — in a
+        background thread — polls the same `{"getUpgradeState": true}` WebSocket
+        channel that recovery.html uses. The two signals combine to judge success:
+        the HTTP outcome, the byte count actually written, upload wall-clock time,
+        and any device-reported `updateStates` (inProgress/inProgressAlt/updateError/
+        updateComplete).
+
+        The primary success signal is an HTTP 200 with body "OK" (per ESPAsyncElegantOTA
+        convention). A `ChunkedEncodingError` or reboot-flavored `ConnectionError` is a
+        safety-net: on some builds or network paths the device restarts before the client
+        finishes reading the response body, and that disconnect is optimistically taken
+        as success unless the WS poller reports otherwise.
+
+        When `monitor` is False, uses a single non-streaming `requests.post(files=...)`
+        with no side channels — fastest possible path, no progress signalling, success
+        is judged solely from the HTTP response.
+
+        Args:
+            filePath (str): Path to the .stfu firmware file.
+            monitor (bool, optional): If True (default), stream chunks + poll device
+                state + apply stricter success heuristics. If False, single-shot POST
+                and trust the HTTP response only.
+            callback (callable, optional): When set, receives progress event dicts:
+                `{'type': 'start',  'total': int}`
+                `{'type': 'chunk',  'sent': int, 'total': int}`
+                `{'type': 'device', 'code': int, 'progress': str, 'raw': dict}`
+                `{'type': 'result', 'ok': bool, 'reason': str}`
+                Ignored when `monitor` is False (no events are emitted).
+            chunkSize (int, optional): Bytes per chunk (progress tick). Defaults to 8192.
+            timeout (float, optional): HTTP read timeout in seconds. Defaults to 300.
+            postUploadPollSeconds (float, optional): After upload returns, keep polling
+                for a final state=6/3 frame for this many seconds. Defaults to 5.
+            minUploadSeconds (float, optional): If the upload returns faster than this
+                and no device-side confirmation ever came in, treat as suspicious even
+                on 200/OK — real flashes take tens of seconds. Defaults to 20.
+
+        Returns:
+            bool: True if the device appears to have accepted the firmware, False
+            otherwise. Rationale is delivered via the final `'result'` callback event
+            when `callback` is set.
+
+        Raises:
+            FileNotFoundError: If `filePath` does not exist.
+            requests.exceptions.Timeout: If the device never responds within `timeout`.
+        """
+        path = pathlib.Path(filePath)
+
+        if not monitor:
+            startedAt = time.monotonic()
+            try:
+                with open(path, 'rb') as f:
+                    files = {'update': (path.name, f, 'application/octet-stream')}
+                    with requests.post(self.getUrl("update"), files=files,
+                                       proxies=self.proxyDict, timeout=timeout) as r:
+                        return self._interpretUpdateResponse(r)
+            except requests.exceptions.ChunkedEncodingError:
+                pass  # fall through to timing heuristic
+            except requests.exceptions.ConnectionError as e:
+                if not self._isRebootDrop(str(e)):
+                    raise
+            # Reboot-flavored disconnect: only trust it if the upload was underway long
+            # enough that a real flash could have happened (real flashes take tens of
+            # seconds). An immediate drop is a fault, not a successful reboot.
+            return (time.monotonic() - startedAt) >= minUploadSeconds
+
+        # --- monitor=True path: streaming upload + WS poller + heuristic success ---
+        fileSize = path.stat().st_size
+        boundary = f"----pixelblazeUpdate{time.time_ns():x}"
+        preamble = (
+            f"--{boundary}\r\n"
+            f'Content-Disposition: form-data; name="update"; filename="{path.name}"\r\n'
+            f"Content-Type: application/octet-stream\r\n\r\n"
+        ).encode()
+        epilogue = f"\r\n--{boundary}--\r\n".encode()
+
+        def emit(evt):
+            if callback:
+                try:
+                    callback(evt)
+                except Exception:
+                    pass  # never let a caller's bug abort a flash
+
+        emit({'type': 'start', 'total': fileSize})
+
+        # Shared state used by both the upload thread (main) and the poller thread.
+        state = {'lastCode': None, 'sawInProgress': False, 'sawComplete': False, 'sawError': False}
+        stopEvt = threading.Event()
+
+        def pollDeviceState():
+            try:
+                # Separate Pixelblaze/WS instance — the main thread's `self` isn't thread-safe.
+                with Pixelblaze(self.ipAddress, ignoreOpenFailure=True,
+                                proxyUrl=self.proxyUrl) as poll_pb:
+                    while not stopEvt.is_set():
+                        try:
+                            frame = poll_pb.wsSendJson({"getUpgradeState": True},
+                                                      expectedResponse="upgradeState")
+                            if frame:
+                                st = json.loads(frame).get("upgradeState", {}) or {}
+                                code = st.get("code", 0)
+                                progress = str(st.get("progress") or "").strip()
+                                if code in (self.updateStates.inProgress,
+                                            self.updateStates.inProgressAlt):
+                                    state['sawInProgress'] = True
+                                if code == self.updateStates.updateError:
+                                    state['sawError'] = True
+                                if code == self.updateStates.updateComplete:
+                                    state['sawComplete'] = True
+                                parsed = self._parseUpgradeProgress(progress)
+                                # Emit on any change to code OR progress string, so mid-file
+                                # ticks (e.g. bytesRemain shrinking) surface too.
+                                lastKey = (state['lastCode'], state.get('lastProgress'))
+                                if (code, progress) != lastKey:
+                                    state['lastCode'] = code
+                                    state['lastProgress'] = progress
+                                    emit({'type': 'device', 'code': code,
+                                          'progress': progress, 'parsed': parsed, 'raw': st})
+                                if code in (self.updateStates.updateError,
+                                            self.updateStates.updateComplete):
+                                    return
+                        except Exception:
+                            pass
+                        stopEvt.wait(0.5)
+            except Exception:
+                pass
+
+        poller = threading.Thread(target=pollDeviceState, daemon=True)
+        poller.start()
+
+        bytesSent = {'n': 0}
+
+        def bodyIter():
+            yield preamble
+            with open(path, 'rb') as f:
+                while True:
+                    chunk = f.read(chunkSize)
+                    if not chunk:
+                        break
+                    yield chunk
+                    bytesSent['n'] += len(chunk)
+                    emit({'type': 'chunk', 'sent': bytesSent['n'], 'total': fileSize})
+            yield epilogue
+
+        headers = {
+            'Content-Type': f'multipart/form-data; boundary={boundary}',
+            'Content-Length': str(len(preamble) + fileSize + len(epilogue)),
+        }
+
+        startedAt = time.monotonic()
+        httpAccepted = None
+        httpReason = ""
+        try:
+            with requests.post(self.getUrl("update"), data=bodyIter(), headers=headers,
+                               proxies=self.proxyDict, timeout=timeout) as r:
+                httpAccepted = self._interpretUpdateResponse(r)
+                httpReason = f"HTTP {r.status_code} body={(r.text or '')[:80]!r}"
+        except requests.exceptions.ChunkedEncodingError:
+            httpAccepted = True
+            httpReason = "connection closed by device mid-response (reboot?)"
+        except requests.exceptions.ConnectionError as e:
+            if self._isRebootDrop(str(e)):
+                httpAccepted = True
+                httpReason = "connection dropped by device (reboot?)"
+            else:
+                stopEvt.set()
+                poller.join(timeout=2.0)
+                raise
+        elapsed = time.monotonic() - startedAt
+
+        # Give the poller a moment to catch a final updateComplete/updateError frame.
+        deadline = time.monotonic() + postUploadPollSeconds
+        while time.monotonic() < deadline and not (state['sawComplete'] or state['sawError']):
+            time.sleep(0.1)
+        stopEvt.set()
+        poller.join(timeout=2.0)
+
+        ok, reason = self._judgeUpdateOutcome(
+            fileSize=fileSize, bytesSent=bytesSent['n'], elapsed=elapsed,
+            minUploadSeconds=minUploadSeconds, httpAccepted=httpAccepted, httpReason=httpReason,
+            sawInProgress=state['sawInProgress'], sawComplete=state['sawComplete'],
+            sawError=state['sawError'],
+        )
+        emit({'type': 'result', 'ok': ok, 'reason': reason})
+        return ok
+
+    @staticmethod
+    def _parseUpgradeProgress(progress: str):
+        """Best-effort parser for upgradeState.progress strings observed from the device.
+
+        Known formats:
+            "Starting"                     → {'phase': 'starting'}
+            "File 4/4 644041 bytes remain" → {'phase': 'file', 'fileIndex': 4,
+                                              'fileCount': 4, 'bytesRemain': 644041}
+
+        Returns None for empty, unknown, or malformed strings. Never raises.
+        """
+        if not progress:
+            return None
+        s = progress.strip()
+        if s == 'Starting':
+            return {'phase': 'starting'}
+        try:
+            parts = s.split()
+            if len(parts) >= 5 and parts[0] == 'File' and '/' in parts[1] and parts[3] == 'bytes':
+                idx_str, total_str = parts[1].split('/', 1)
+                return {
+                    'phase': 'file',
+                    'fileIndex': int(idx_str),
+                    'fileCount': int(total_str),
+                    'bytesRemain': int(parts[2]),
+                }
+        except (ValueError, IndexError):
+            pass
+        return None
+
+    @staticmethod
+    def _isRebootDrop(msg: str) -> bool:
+        return ('RemoteDisconnected' in msg
+                or 'Connection aborted' in msg
+                or 'Connection reset' in msg)
+
+    @staticmethod
+    def _judgeUpdateOutcome(*, fileSize, bytesSent, elapsed, minUploadSeconds,
+                            httpAccepted, httpReason, sawInProgress, sawComplete,
+                            sawError) -> tuple[bool, str]:
+        """Combine byte-transfer, timing, HTTP, and WS signals into one accept/reject
+        verdict with a human-readable reason string."""
+        # Device explicitly told us it failed: authoritative reject.
+        if sawError:
+            return (False, f"device reported upgradeState.updateError; {httpReason}")
+        # Device explicitly told us it finished: authoritative accept.
+        if sawComplete:
+            return (True, f"device reported upgradeState.updateComplete; {httpReason}")
+        # Not enough bytes made it out — POST returned before we streamed the file.
+        if bytesSent < fileSize:
+            return (False, f"only sent {bytesSent}/{fileSize} bytes before upload returned; {httpReason}")
+        # HTTP said reject and device didn't contradict.
+        if httpAccepted is False:
+            return (False, f"HTTP rejected the file; {httpReason}")
+        # HTTP said accept but device never even entered 'in progress' AND upload was
+        # suspiciously fast — real flashes take tens of seconds.
+        if httpAccepted and not sawInProgress and elapsed < minUploadSeconds:
+            return (False, f"upload finished in {elapsed:.2f}s (< {minUploadSeconds}s) "
+                           f"and device never confirmed progress; {httpReason}")
+        # HTTP said accept, bytes made it, no error reported — best-guess success even
+        # if the WS was silent (some builds don't stream progress reliably).
+        if httpAccepted:
+            confirm = "with device in-progress signal" if sawInProgress else "no device confirmation available"
+            return (True, f"HTTP accepted, all bytes sent in {elapsed:.1f}s; {confirm}")
+        return (False, f"indeterminate outcome; {httpReason}")
+
+    @staticmethod
+    def _interpretUpdateResponse(r) -> bool:
+        """Parses an /update HTTP response. Returns True on accept, False on rejection.
+
+        ESPAsyncWebServer OTA returns "OK" on success and "FAIL" (sometimes with
+        detail) on rejection. Some builds respond with an empty body on success.
+        """
+        if r.status_code != 200:
+            return False
+        body = (r.text or '').strip().upper()
+        return not ('FAIL' in body or 'ERROR' in body)
 
     # --- SETTINGS menu: UPDATES section: convenience functions
 

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setuptools.setup(
       "click>=8.0",
       "json5",
       "lzstring",
+      "tqdm",
     ],
     packages=["pixelblaze"],
     python_requires='>=3.9',


### PR DESCRIPTION
Applies directly to `main` — no dependencies.

## Summary

I had a fairly bricked Pixelblaze: the web UI barely loaded and it wouldn't switch wifi, while the CLI and websocket API worked intermittently. This got it flashed, and I've since used it to upgrade the rest of my boards.

- `Pixelblaze.installFirmwareFile(path, *, monitor=True, callback=None, ...)` — streaming multipart POST to `/update`, mirroring the `recovery.html` flow.
- `monitor=True` (default) streams chunks alongside a background websocket poller (`getUpgradeState`), then reaches a verdict from the HTTP outcome, bytes sent, elapsed time and device state.
- `monitor=False` is a single-shot `requests.post(files=...)` — no threads, no callbacks — with a timing check on reboot-flavoured disconnects so an immediate fault isn't read as success.
- The callback receives event dicts: `start`, `chunk`, `device` (with the parsed `file X/Y, N bytes remain`), `result`.
- `updateStates` gains `inProgressAlt = 7`; magic numbers replaced with enum references.
- `pb update <file>` — tqdm progress bar (byte scaling, rate, ETA) with device state lines via `tqdm.write`. Options: `--no-ver`, `--no-monitor`, `--timeout`, `--chunk`.
- `tqdm` added to `install_requires`.

## Test plan

- [x] `pb --ip <ip> update <file.stfu>` on a live device: progress bar, `[device] state=…` lines, final `updateComplete`, device reboots
- [x] `--no-monitor`: single-shot POST completes and returns
- [x] `--no-ver`: no pre-flash websocket round-trip
- [x] A device dropping the connection before `minUploadSeconds` returns False in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
