### PR TITLE
CLI: pb top realtime dashboard + expanded pb subcommands

### DIFF
--- a/examples/cli_examples.sh
+++ b/examples/cli_examples.sh
@@ -20,6 +20,27 @@ pb --ip 192.168.1.100 pixels
 pb ping
 
 
+# Realtime Dashboard (top-style)
+# ==============================
+
+# Live table of every Pixelblaze on the LAN — FPS, memory, active pattern,
+# uptime, brightness, etc. Devices that drop off go red; when they rejoin
+# they turn back green.
+pb top
+
+# Faster redraw
+pb top -n 0.25
+
+# Sort by frames-per-second
+pb top --sort fps
+
+# One-shot machine-readable snapshot (great for cron / dashboards)
+pb top --once --json | jq .
+
+# Rediscover every 10s (default 30s) — pick up devices that just booted
+pb top -r 10
+
+
 # Basic Controls
 # =============
 

--- a/examples/cli_examples.sh
+++ b/examples/cli_examples.sh
@@ -64,22 +64,26 @@ pb map --csv
 # =================
 
 # Start the sequencer
-pb seq play
+pb playlist play
 
 # Pause the sequencer
-pb seq pause
+pb playlist pause
 
 # Go to next pattern
-pb seq next
+pb playlist next
 
 # Jump to random pattern
-pb seq rand
+pb playlist rand
 
 # Set all patterns to 10 seconds
-pb seq len 10
+pb playlist len 10
 
 # Set all patterns to 30 seconds and save
-pb seq len 30 --save
+pb playlist len 30 --save
+
+# Save the playlist matching case insensitive CSV pattern name substrings,
+# each 15 seconds, shuffle the supplied order
+pb playlist set 'blink fade,block reflections,honeycom,xorc' --shuffle -d 15
 
 
 # Live Pattern Rendering (Temporary)

--- a/pixelblaze/cli/cli.py
+++ b/pixelblaze/cli/cli.py
@@ -30,6 +30,7 @@ from pixelblaze.cli.cli_utils import cli, log, no_save_option, input_arg, read_i
                                      get_cache_dir, check, parse_vars, get_pixelblaze, discover_pixelblaze, \
                                      enumerate_pixelblazes, cache_ip, _read_cache, _write_cache, \
                                      _fetch_device_config, update_device_cache, lookup_cached_device
+from pixelblaze.cli.top import register as _register_top
 
 @click.group()
 @click.option(
@@ -2145,6 +2146,10 @@ def cache_refresh(query, all_devices, conn_timeout):
         log(f"Refreshed {len(refreshed)}/{len(targets)} device(s).")
     else:
         raise click.ClickException("Could not refresh any devices.")
+
+
+# `pb top` lives in a sibling module for size; register it onto the group here.
+_register_top(pixelblaze)
 
 
 def main():

--- a/pixelblaze/cli/cli.py
+++ b/pixelblaze/cli/cli.py
@@ -27,7 +27,9 @@ import click
 import pathlib
 from pixelblaze.pixelblaze import Pixelblaze, PBB
 from pixelblaze.cli.cli_utils import cli, log, no_save_option, input_arg, read_input, parse_json, jsons, \
-                                     get_cache_dir, check, parse_vars, get_pixelblaze, discover_pixelblaze
+                                     get_cache_dir, check, parse_vars, get_pixelblaze, discover_pixelblaze, \
+                                     enumerate_pixelblazes, cache_ip, _read_cache, _write_cache, \
+                                     _fetch_device_config, update_device_cache, lookup_cached_device
 
 @click.group()
 @click.option(
@@ -43,8 +45,15 @@ from pixelblaze.cli.cli_utils import cli, log, no_save_option, input_arg, read_i
     help='Command timeout in seconds (default: 5.0)',
     show_default=True
 )
+@click.option(
+    '--retries',
+    type=int,
+    default=3,
+    help='Number of retries on connection errors (default: 3)',
+    show_default=True
+)
 @click.pass_context
-def pixelblaze(ctx, ip, timeout):
+def pixelblaze(ctx, ip, timeout, retries):
     """
     Pixelblaze LED Controller CLI
 
@@ -53,6 +62,88 @@ def pixelblaze(ctx, ip, timeout):
     ctx.ensure_object(dict)
     ctx.obj['ip'] = ip
     ctx.obj['timeout'] = timeout
+    ctx.obj['retries'] = retries
+
+
+@pixelblaze.command()
+@click.option('--name', '-n', 'name_filter', default=None,
+              help='Filter by device name (case-insensitive substring match, implies --full)')
+@click.option('--ip', '-i', 'ip_filter', default=None,
+              help='Filter by IP address (substring match)')
+@click.option('--timeout', '-t', 'scan_timeout', type=int, default=3000,
+              help='Beacon listen timeout in milliseconds (default: 3000)',
+              show_default=True)
+@click.option('--full', '--slow', '-s', '-f', 'slow', is_flag=True,
+              help='Connect to each device to fetch name, version, config (parallel)')
+@click.option('--no-cache', is_flag=True, help='Do not cache the selected IP')
+@click.pass_context
+def find(ctx, name_filter, ip_filter, scan_timeout, slow, no_cache):
+    """
+    Discover and enumerate all Pixelblazes on the network.
+
+    By default runs fast: listens for UDP beacons and returns IPs only.
+    Use --full/--slow to connect to each device (in parallel) and fetch names,
+    version, pixel count, etc. Using --name implies --full.
+
+    Prints JSONL (one JSON object per line) to stdout. Discovery progress
+    is logged to stderr.
+
+    The first matching device (after any filters) is cached as the default
+    IP for subsequent commands.
+
+    \b
+    Examples:
+        pb find                          # Fast: just IPs from beacons
+        pb find --full                   # Connect to each, get full info (--slow is an alias)
+        pb find --name living            # Filter by name (implies --full)
+        pb find --ip 192.168.1           # Filter by IP substring (fast)
+        pb find --name tree --ip 10.     # Combine filters
+        pb find --timeout 5000           # Scan longer for slow networks
+        pb find --no-cache               # Don't update cached IP
+        pb find 2>/dev/null              # Quiet mode (stdout JSONL only)
+    """
+    # --name requires device info, so imply --full
+    if name_filter:
+        slow = True
+
+    devices = enumerate_pixelblazes(timeout=scan_timeout, slow=slow)
+
+    if not devices:
+        raise click.ClickException("No Pixelblazes found on the network.")
+
+    # Apply filters
+    matched = []
+    for dev in devices:
+        if name_filter and name_filter.lower() not in dev.get('name', '').lower():
+            continue
+        if ip_filter and ip_filter not in dev.get('ip', ''):
+            continue
+        matched.append(dev)
+
+    log(f"\nFound {len(devices)} device(s), {len(matched)} matched filters.")
+
+    if not matched:
+        filters = []
+        if name_filter:
+            filters.append(f"--name '{name_filter}'")
+        if ip_filter:
+            filters.append(f"--ip '{ip_filter}'")
+        raise click.ClickException(
+            f"No devices matched filters: {' '.join(filters)}. "
+            f"Found {len(devices)} device(s) total."
+        )
+
+    # Print all matched devices as JSONL to stdout
+    for dev in matched:
+        click.echo(jsonlib.dumps(dev, separators=(',', ':')))
+
+    # Cache the first match
+    selected = matched[0]
+    if not no_cache:
+        cache_ip(selected['ip'])
+        log(f"Cached IP: {selected['ip']}" + (f" ({selected['name']})" if selected.get('name') else ""))
+    else:
+        log(f"Selected (not cached): {selected['ip']}" + (f" ({selected['name']})" if selected.get('name') else ""))
 
 
 @cli(pixelblaze)
@@ -72,7 +163,18 @@ def pixels(pb: Pixelblaze, count, no_save):
         current_count = pb.getPixelCount()
         click.echo(f"{current_count}")
     else:
-        pb.setPixelCount(count, saveToFlash=not no_save)
+        current_count = pb.getPixelCount()
+        if count < current_count:
+            # Blank orphaned LEDs by toggling brightness off around the change
+            log(f"Reducing pixel count ({current_count} → {count})...")
+            prev_brightness = pb.getBrightnessSlider()
+            pb.setBrightnessSlider(0.0)
+            time.sleep(0.1)
+            pb.setPixelCount(count, saveToFlash=not no_save)
+            time.sleep(0.1)
+            pb.setBrightnessSlider(prev_brightness)
+        else:
+            pb.setPixelCount(count, saveToFlash=not no_save)
         action = "set" if no_save else "saved"
         log(f"Pixel count {action} to {count}")
 
@@ -146,9 +248,10 @@ def off(pb: Pixelblaze, pause_sequencer, no_save):
 @cli(pixelblaze)
 @input_arg
 @click.option('--csv', is_flag=True, help='Output as csv instead of Pixelblaze 3-arrays')
-def map(pb: Pixelblaze, input, csv):
+@click.option('--clear', is_flag=True, help='Clear/remove the current pixel map from the device')
+def map(pb: Pixelblaze, input, csv, clear):
     """
-    Get or set the pixel map function.
+    Get, set, or clear the pixel map function.
 
     INPUT is an optional JavaScript file path or inline code. Can also be
     piped via stdin. If no input is provided, the current map function
@@ -159,7 +262,17 @@ def map(pb: Pixelblaze, input, csv):
         pb map                       # Get current map coordinates (normalized 0-1)
         pb map map.js                # Set map from file
         pb map < map.js              # Set map from stdin
+        pb map --clear               # Remove the current pixel map
     """
+    check(not (clear and csv), "Cannot use --clear and --csv together")
+
+    if clear:
+        log("Clearing pixel map...")
+        pb.deleteFile('/pixelmap.txt')
+        pb.deleteFile('/pixelmap.dat')
+        log("Pixel map cleared")
+        return
+
     content, _ = read_input(input, "map", required=False)
     setting = content is not None
 
@@ -183,9 +296,9 @@ def map(pb: Pixelblaze, input, csv):
 
 
 @pixelblaze.group()
-def seq():
+def playlist():
     """
-    Sequencer and playlist control commands.
+    Playlist and sequencer control commands.
 
     Control the Pixelblaze pattern sequencer, including play/pause,
     navigation, and playlist management.
@@ -193,7 +306,7 @@ def seq():
     pass
 
 
-@cli(seq)
+@cli(playlist)
 @no_save_option
 def pause(pb: Pixelblaze, no_save):
     """
@@ -201,8 +314,8 @@ def pause(pb: Pixelblaze, no_save):
 
     \b
     Examples:
-        pb seq pause           # Pause sequencer (saved to flash)
-        pb seq pause --no-save    # Pause (temporary only)
+        pb playlist pause           # Pause sequencer (saved to flash)
+        pb playlist pause --no-save    # Pause (temporary only)
     """
     log("Pausing sequencer...")
     pb.pauseSequencer(saveToFlash=not no_save)
@@ -210,7 +323,7 @@ def pause(pb: Pixelblaze, no_save):
     log(f"Sequencer {action}")
 
 
-@cli(seq)
+@cli(playlist)
 @no_save_option
 def play(pb: Pixelblaze, no_save):
     """
@@ -218,8 +331,8 @@ def play(pb: Pixelblaze, no_save):
 
     \b
     Examples:
-        pb seq play           # Start/resume sequencer (saved to flash)
-        pb seq play --no-save    # Start (temporary only)
+        pb playlist play           # Start/resume sequencer (saved to flash)
+        pb playlist play --no-save    # Start (temporary only)
     """
     log("Starting sequencer...")
     pb.playSequencer(saveToFlash=not no_save)
@@ -227,7 +340,7 @@ def play(pb: Pixelblaze, no_save):
     log(f"Sequencer {action}")
 
 
-@cli(seq)
+@cli(playlist)
 @no_save_option
 def next(pb: Pixelblaze, no_save):
     """
@@ -237,8 +350,8 @@ def next(pb: Pixelblaze, no_save):
 
     \b
     Examples:
-        pb seq next           # Next pattern (saved to flash)
-        pb seq next --no-save    # Next pattern (temporary only)
+        pb playlist next           # Next pattern (saved to flash)
+        pb playlist next --no-save    # Next pattern (temporary only)
     """
     log("Advancing to next pattern...")
     pb.nextSequencer(saveToFlash=not no_save)
@@ -246,7 +359,7 @@ def next(pb: Pixelblaze, no_save):
     log(action)
 
 
-@cli(seq)
+@cli(playlist)
 def rand(pb: Pixelblaze):
     """
     Jump to a random pattern.
@@ -255,7 +368,7 @@ def rand(pb: Pixelblaze):
 
     \b
     Examples:
-        pb seq rand    # Jump to random pattern
+        pb playlist rand    # Jump to random pattern
     """
     import random as rand
 
@@ -272,7 +385,7 @@ def rand(pb: Pixelblaze):
     log(f"Now playing: {pattern_name}")
 
 
-@cli(seq, name='len')
+@cli(playlist, name='len')
 @click.argument('seconds', type=float)
 @no_save_option
 def set_duration(pb: Pixelblaze, seconds, no_save):
@@ -285,8 +398,8 @@ def set_duration(pb: Pixelblaze, seconds, no_save):
 
     \b
     Examples:
-        pb seq len 10          # Set all durations to 10 seconds (saved)
-        pb seq len 30 --no-save   # Set to 30 seconds (temporary only)
+        pb playlist len 10          # Set all durations to 10 seconds (saved)
+        pb playlist len 30 --no-save   # Set to 30 seconds (temporary only)
     """
     check(seconds > 0, "Duration must be greater than 0")
 
@@ -310,6 +423,112 @@ def set_duration(pb: Pixelblaze, seconds, no_save):
 
     action = "set" if no_save else "saved"
     log(f"Playlist updated and {action}: all patterns set to {seconds}s")
+
+
+@cli(playlist, name='set')
+@click.argument('terms', type=str)
+@click.option('--duration', '-d', type=float, default=30.0,
+              show_default=True, help='Seconds per pattern')
+@click.option('--shuffle', is_flag=True,
+              help='Shuffle the resolved order before writing the playlist')
+@no_save_option
+def playlist_set(pb: Pixelblaze, terms, duration, shuffle, no_save):
+    """
+    Build a playlist from a CSV of pattern-name searches and/or .js file paths, then play it.
+
+    For each comma-separated term:
+      1. case-insensitive substring match against stored pattern names, or
+      2. treated as a local .js file path — uploaded to the device, then used.
+
+    Unresolved terms are logged and skipped (best-effort — never fails the whole run).
+    Quote the whole arg if any term contains spaces or shell-special characters.
+
+    \b
+    Examples:
+        pb playlist set 'sparkle,rainbow,wave'
+        pb playlist set 'src/patterns/tools/colorOrder.js,sparkle' -d 10
+        pb playlist set 'foo,bar,baz' --no-save
+    """
+    check(terms.strip(), "Provide a comma-separated list of names or .js file paths")
+    check(duration > 0, "Duration must be greater than 0")
+
+    parts = [t.strip() for t in terms.split(',') if t.strip()]
+    check(parts, "No terms provided")
+
+    log("Fetching pattern list...")
+    patterns = dict(pb.getPatternList())  # {id: name}; local copy so we can extend it
+
+    resolved = []  # [(patternId, displayName), ...]
+
+    for term in parts:
+        t_lower = term.lower()
+        matches = [(pid, name) for pid, name in patterns.items()
+                   if t_lower in name.lower()]
+        if matches:
+            pid, name = matches[0]
+            resolved.append((pid, name))
+            extra = ''
+            if len(matches) > 1:
+                others = ', '.join(n for _, n in matches[1:4])
+                more = '...' if len(matches) > 4 else ''
+                extra = f"  [+{len(matches) - 1} more: {others}{more}]"
+            log(f"  ✓ '{term}' → {name}{extra}")
+            continue
+
+        path = pathlib.Path(term)
+        if path.is_file() and path.suffix.lower() == '.js':
+            try:
+                code = path.read_text()
+                if 'export' not in code:
+                    code = 'export function render(index) { ' + code + ' ; }'
+                pattern_name = path.stem
+                existing_pid = next(
+                    (pid for pid, name in patterns.items()
+                     if name.lower() == pattern_name.lower()),
+                    None
+                )
+                img_path = pathlib.Path(__file__).parent / '../../site/images/preview_placeholder.jpg'
+                preview = img_path.read_bytes()
+                verb = 'updating' if existing_pid else 'uploading'
+                log(f"  ↑ '{term}' → {verb} '{pattern_name}'")
+                pid = pb.savePattern(
+                    previewImage=preview,
+                    sourceCode=code,
+                    name=pattern_name,
+                    id=existing_pid,
+                    allowCache=True,
+                )
+                resolved.append((pid, pattern_name))
+                patterns[pid] = pattern_name  # so later terms can name-match this
+                continue
+            except Exception as e:
+                log(f"  ✗ '{term}' → file upload failed: {e}; skipping")
+                continue
+
+        log(f"  ✗ '{term}' → no name match and not a .js file; skipping")
+
+    check(resolved, "No terms resolved to a pattern; playlist unchanged")
+
+    if shuffle:
+        import random as rand
+        rand.shuffle(resolved)
+        log(f"Shuffled order: {', '.join(name for _, name in resolved)}")
+
+    ms_per = int(duration * 1000)
+    log("Building playlist...")
+    playlist = pb.getSequencerPlaylist()
+    playlist['playlist']['items'] = [{"id": pid, "ms": ms_per} for pid, _ in resolved]
+
+    log(f"Setting playlist ({len(resolved)} pattern{'s' if len(resolved) != 1 else ''}, "
+        f"{duration}s each)...")
+    pb.setSequencerPlaylist(playlist, saveToFlash=not no_save)
+
+    log("Switching to Playlist mode and starting...")
+    pb.setSequencerMode(Pixelblaze.sequencerModes.Playlist, saveToFlash=not no_save)
+    pb.playSequencer(saveToFlash=not no_save)
+
+    action = "set (temporary)" if no_save else "saved"
+    log(f"Playlist {action}. Playing: {resolved[0][1]}")
 
 
 @cli(pixelblaze)
@@ -508,29 +727,40 @@ def _find_pattern(pb: Pixelblaze, search: str, exact: bool = False):
     Returns:
         tuple: (pattern_id, pattern_name) or (None, None) if not found
     """
+    results = _find_patterns(pb, search, exact)
+    return results[0] if results else (None, None)
+
+
+def _find_patterns(pb: Pixelblaze, search: str, exact: bool = False):
+    """Find all patterns matching a name or ID.
+
+    Returns:
+        list[tuple]: List of (pattern_id, pattern_name) tuples
+    """
     log("Fetching pattern list...")
     patterns = pb.getPatternList()
 
     # Try by ID first
     if Pixelblaze.isPatternId(search):
         pattern_name = patterns.get(search)
-        return (search, pattern_name) if pattern_name else (None, None)
+        return [(search, pattern_name)] if pattern_name else []
 
     # Search by name
     if not patterns:
-        return (None, None)
+        return []
 
     pattern_regex = re.compile(search, re.IGNORECASE)
+    results = []
 
     for pattern_id, pattern_name in patterns.items():
         if exact:
             if pattern_name.lower() == search.lower():
-                return (pattern_id, pattern_name)
+                results.append((pattern_id, pattern_name))
         else:
             if pattern_regex.search(pattern_name):
-                return (pattern_id, pattern_name)
+                results.append((pattern_id, pattern_name))
 
-    return (None, None)
+    return results
 
 
 def _handle_cat_mode(pb: Pixelblaze, input, exact):
@@ -580,7 +810,8 @@ def _handle_write_mode(pb: Pixelblaze, input, write_target, img, variables, no_s
         check(pattern_name, f"Pattern ID {write_target} not found")
     else:
         pattern_name = write_target
-        pattern_id = None
+        # Look up existing pattern by name to overwrite instead of creating a dupe
+        pattern_id, _ = _find_pattern(pb, write_target, exact=True)
 
     if "export" not in code:
         code = 'export function render(index) { ' + code + ' ; }'
@@ -590,7 +821,9 @@ def _handle_write_mode(pb: Pixelblaze, input, write_target, img, variables, no_s
     with open(img, 'rb') as f:
         preview_image = f.read()
 
-    log(f"Saving pattern '{pattern_name}' (Supplied ID: {pattern_id})...")
+    is_update = pattern_id is not None
+    log(f"{'Updating' if is_update else 'Creating'} pattern '{pattern_name}'"
+        f"{f' (ID: {pattern_id})' if is_update else ''}...")
     pattern_id = pb.savePattern(
         previewImage=preview_image,
         sourceCode=code,
@@ -599,7 +832,7 @@ def _handle_write_mode(pb: Pixelblaze, input, write_target, img, variables, no_s
         allowCache=True
     )
 
-    log(f"Pattern '{pattern_name}' (ID: {pattern_id}) created successfully!")
+    log(f"Pattern '{pattern_name}' (ID: {pattern_id}) {'updated' if is_update else 'created'} successfully!")
     _set_vars_and_controls(pb, variables, not no_save)
     jsons({'id': pattern_id})
 
@@ -664,30 +897,448 @@ def _set_vars_and_controls(pb: Pixelblaze, variables, save=False):
 
 
 @cli(pixelblaze)
-def cfg(pb: Pixelblaze):
+@click.option('--name', 'device_name', default=None, help='Set device name')
+@click.option('--pixels', type=int, default=None, help='Set pixel count')
+@click.option('--brightness', type=float, default=None, help='Set brightness (0.0-1.0)')
+@click.option('--max-brightness', type=int, default=None, help='Set brightness limit (0-100%%)')
+@click.option('--led-type',
+              type=click.Choice(['WS2812', 'APA102', 'SK9822', 'WS2801', 'OutputExpander', 'off'],
+                                case_sensitive=False),
+              default=None, help='Set LED type')
+@click.option('--color-order',
+              type=click.Choice(['RGB', 'RBG', 'BRG', 'BGR', 'GRB', 'GBR',
+                                 'RGBW', 'GRBW', 'RGB-W', 'GRB-W'],
+                                case_sensitive=False),
+              default=None, help='Set color order')
+@click.option('--data-speed', type=int, default=None, help='Set LED data speed (Hz, advanced)')
+@click.option('--cpu',
+              type=click.Choice(['low', 'medium', 'high'], case_sensitive=False),
+              default=None, help='Set CPU speed (80/160/240 MHz, requires reboot)')
+@click.option('--discovery/--no-discovery', default=None,
+              help='Enable/disable Electromage discovery service')
+@click.option('--timezone', 'tz', default=None, help='Set timezone (Unix tz string, e.g. "America/New_York")')
+@click.option('--auto-off/--no-auto-off', 'auto_off_enable', default=None,
+              help='Enable/disable auto-off scheduler')
+@click.option('--auto-off-start', default=None, help='Auto-off start time (HH:MM)')
+@click.option('--auto-off-end', default=None, help='Auto-off end time (HH:MM)')
+@click.option('--network-power-save/--no-network-power-save', 'net_power_save', default=None,
+              help='Enable/disable WiFi power save (requires reboot)')
+@click.option('--simple-ui/--no-simple-ui', 'simple_ui', default=None,
+              help='Enable/disable Simple UI mode')
+@click.option('--learning-ui/--no-learning-ui', 'learning_ui', default=None,
+              help='Enable/disable Learning UI mode')
+@click.option('--brand-name', default=None, help='Set brand name (VAR/OEM use)')
+@click.option('--leader-id', type=int, default=None,
+              help='Group-sync leader chipId to follow (0 = Solo/Leader)')
+@click.option('--node-id', type=int, default=None,
+              help="This device's sync-group node id (readable in patterns via nodeId())")
+@no_save_option
+def cfg(pb: Pixelblaze, device_name, pixels, brightness, max_brightness,
+        led_type, color_order, data_speed, cpu, discovery, tz,
+        auto_off_enable, auto_off_start, auto_off_end,
+        net_power_save, simple_ui, learning_ui, brand_name,
+        leader_id, node_id, no_save):
     """
-    Fetch and display most of the configuration from the Pixelblaze.
+    Get or set Pixelblaze configuration.
 
-    This mimics the web UI's initial configuration fetch, retrieving:
-    - Device config
-    - Pattern list
-    - Playlist
-    - Sequencer settings
-    - And more
+    With no options, fetches and displays the full configuration as JSON.
+    With options, sets the specified values (multiple can be combined).
 
     \b
     Examples:
-        pb cfg
-        pb cfg | yq -P          # Pretty-printed YAML
+        pb cfg                                  # Show full config
+        pb cfg | jq .config.name                # Query a field
+        pb cfg --name "My Pixelblaze"           # Set device name
+        pb cfg --pixels 300 --brightness 0.5    # Set multiple values
+        pb cfg --led-type WS2812 --color-order GRB
+        pb cfg --led-type APA102 --data-speed 2000000
+        pb cfg --cpu high                       # Requires reboot
+        pb cfg --discovery --timezone America/New_York
+        pb cfg --auto-off --auto-off-start 23:00 --auto-off-end 07:00
+        pb cfg --leader-id 0 --node-id 1        # Solo/Leader as node 1
+        pb cfg --leader-id 9238196 --node-id 2  # Follow leader by chipId
+        pb cfg --no-save --brightness 0.2       # Temporary only
     """
-    log("Fetching configurations...")
-    jsons({
-        'config': pb.getConfigSettings(),
-        'patterns': pb.getPatternList(),
-        'playlist': pb.getSequencerPlaylist(),
-        'sequencer': pb.getConfigSequencer()
-    })
+    save = not no_save
 
+    # Collect all set operations
+    changes = {}
+
+    if device_name is not None:
+        pb.setDeviceName(device_name)
+        changes['name'] = device_name
+
+    if pixels is not None:
+        check(pixels > 0, "Pixel count must be positive")
+        pb.setPixelCount(pixels, saveToFlash=save)
+        changes['pixelCount'] = pixels
+
+    if brightness is not None:
+        check(0.0 <= brightness <= 1.0, "Brightness must be between 0.0 and 1.0")
+        pb.setBrightnessSlider(brightness, saveToFlash=save)
+        changes['brightness'] = brightness
+
+    if max_brightness is not None:
+        check(0 <= max_brightness <= 100, "Max brightness must be between 0 and 100")
+        pb.setBrightnessLimit(max_brightness, saveToFlash=save)
+        changes['maxBrightness'] = max_brightness
+
+    if led_type is not None:
+        led_type_map = {
+            'ws2812': Pixelblaze.ledTypes.WS2812,
+            'apa102': Pixelblaze.ledTypes.APA102,
+            'sk9822': Pixelblaze.ledTypes.SK9822,
+            'ws2801': Pixelblaze.ledTypes.WS2801,
+            'outputexpander': Pixelblaze.ledTypes.OutputExpander,
+            'off': Pixelblaze.ledTypes.noLeds,
+        }
+        lt = led_type_map[led_type.lower()]
+        pb.setLedType(lt, dataSpeed=data_speed, saveToFlash=save)
+        changes['ledType'] = led_type
+        if data_speed is not None:
+            changes['dataSpeed'] = data_speed
+    elif data_speed is not None:
+        pb.setDataSpeed(data_speed, saveToFlash=save)
+        changes['dataSpeed'] = data_speed
+
+    if color_order is not None:
+        co = Pixelblaze.colorOrders(color_order.upper())
+        pb.setColorOrder(co, saveToFlash=save)
+        changes['colorOrder'] = color_order
+
+    if cpu is not None:
+        cpu_map = {
+            'low': Pixelblaze.cpuSpeeds.low,
+            'medium': Pixelblaze.cpuSpeeds.medium,
+            'high': Pixelblaze.cpuSpeeds.high,
+        }
+        pb.setCpuSpeed(cpu_map[cpu.lower()])
+        changes['cpuSpeed'] = cpu
+        log("Note: CPU speed change requires reboot to take effect")
+
+    if discovery is not None:
+        pb.setDiscovery(discovery, timezoneName=tz)
+        changes['discoveryEnable'] = discovery
+        if tz is not None:
+            changes['timezone'] = tz
+    elif tz is not None:
+        pb.setTimezone(tz)
+        changes['timezone'] = tz
+
+    if auto_off_enable is not None:
+        pb.setAutoOffEnable(auto_off_enable, saveToFlash=save)
+        changes['autoOffEnable'] = auto_off_enable
+
+    if auto_off_start is not None:
+        pb.setAutoOffStart(auto_off_start, saveToFlash=save)
+        changes['autoOffStart'] = auto_off_start
+
+    if auto_off_end is not None:
+        pb.setAutoOffEnd(auto_off_end, saveToFlash=save)
+        changes['autoOffEnd'] = auto_off_end
+
+    if net_power_save is not None:
+        pb.setNetworkPowerSave(net_power_save)
+        changes['networkPowerSave'] = net_power_save
+        log("Note: Network power save change requires reboot to take effect")
+
+    if simple_ui is not None:
+        pb.setSimpleUiMode(simple_ui)
+        changes['simpleUiMode'] = simple_ui
+
+    if learning_ui is not None:
+        pb.setLearningUiMode(learning_ui)
+        changes['learningUiMode'] = learning_ui
+
+    if brand_name is not None:
+        pb.setBrandName(brand_name)
+        changes['brandName'] = brand_name
+
+    # Group-sync: leaderId + nodeId bundled in one payload so they commit atomically
+    sync_payload = {}
+    if leader_id is not None:
+        sync_payload['leaderId'] = leader_id
+    if node_id is not None:
+        sync_payload['nodeId'] = node_id
+    if sync_payload:
+        sync_payload['save'] = save
+        pb.wsSendJson(sync_payload, expectedResponse=None)
+        if leader_id is not None:
+            changes['leaderId'] = leader_id
+            if leader_id == 0:
+                log("Note: leaderId=0 → Solo/Leader mode (this device broadcasts or runs standalone)")
+            else:
+                log(f"Note: this device will follow leader chipId={leader_id}")
+        if node_id is not None:
+            changes['nodeId'] = node_id
+
+    if changes:
+        for k, v in changes.items():
+            log(f"  {k}: {v}")
+        action = "set" if no_save else "saved"
+        log(f"{len(changes)} setting(s) {action}")
+    else:
+        # No options — read mode: dump full config
+        log("Fetching configurations...")
+        try:
+            wifi = Pixelblaze.getWifiStatus(pb.ipAddress)
+            try:
+                wifi['mode'] = Pixelblaze.wifiModes(wifi['status']).name
+            except (ValueError, KeyError):
+                pass
+        except Exception as e:
+            wifi = {'error': str(e)}
+        jsons({
+            'config': pb.getConfigSettings(),
+            'wifi': wifi,
+            'patterns': pb.getPatternList(),
+            'playlist': pb.getSequencerPlaylist(),
+            'sequencer': pb.getConfigSequencer()
+        })
+
+
+## ─── WiFi ─────────────────────────────────────────────────────────────────────
+
+@pixelblaze.group()
+def wifi():
+    """
+    WiFi configuration commands.
+
+    View WiFi status, scan for networks, join a network, or configure
+    the Pixelblaze as an access point. These commands use HTTP-only
+    endpoints and work in ad-hoc/setup mode (192.168.4.1).
+    """
+    pass
+
+
+@cli(wifi, conn=False)
+def status(ctx):
+    """
+    Show the current WiFi status.
+
+    Displays mode (setup/AP/client), IP address, SSID, and MAC address.
+
+    \b
+    Examples:
+        pb wifi status
+        pb wifi status --ip 192.168.4.1
+    """
+    ip = discover_pixelblaze(ctx)
+    log(f"Fetching WiFi status from {ip}...")
+    result = Pixelblaze.getWifiStatus(ip, timeout=ctx.obj['timeout'])
+
+    mode_names = {255: 'setup', 6: 'ap', 3: 'client'}
+    mode = result.get('status', -1)
+    result['modeName'] = mode_names.get(mode, f'unknown({mode})')
+    jsons(result)
+
+
+@cli(wifi, conn=False)
+def scan(ctx):
+    """
+    Scan for available WiFi networks.
+
+    Initiates a WiFi scan and displays nearby access points sorted by
+    signal strength, including SSID, signal (RSSI), channel, and security.
+
+    \b
+    Examples:
+        pb wifi scan
+        pb wifi scan --ip 192.168.4.1
+    """
+    ip = discover_pixelblaze(ctx)
+    log(f"Scanning for WiFi networks from {ip}...")
+    results = Pixelblaze.getWifiScan(ip, timeout=ctx.obj['timeout'] * 3)
+
+    if not results:
+        log("No networks found (scan may still be in progress, try again)")
+        return
+
+    results.sort(key=lambda ap: ap.get('rssi', -999), reverse=True)
+    jsons(results)
+
+    log(f"\n  {'SSID':<32} {'RSSI':>5}  {'CH':>3}  {'SECURE'}")
+    log(f"  {'─' * 32} {'─' * 5}  {'─' * 3}  {'─' * 6}")
+    for ap in results:
+        ssid = ap.get('ssid', '?')
+        rssi = ap.get('rssi', '?')
+        ch = ap.get('channel', '?')
+        secure = 'yes' if ap.get('secure') else 'no'
+        log(f"  {ssid:<32} {rssi:>5}  {ch:>3}  {secure}")
+
+
+@cli(wifi, conn=False)
+@click.option('--ssid', '-s', required=True, help='SSID of the network to join')
+@click.option('--password', '-p', default='', help='Network password (empty for open networks)')
+@click.option('--no-discover', is_flag=True, help='Disable Electromage discovery service')
+def join(ctx, ssid, password, no_discover):
+    """
+    Join a WiFi network as a client.
+
+    Connects the Pixelblaze to an existing WiFi network. After joining,
+    the device will be reachable at its new IP (check your router or
+    run 'pb find' on the target network).
+
+    \b
+    Examples:
+        pb wifi join -s "MyNetwork" -p "secret"
+        pb wifi join --ssid "OpenNetwork"
+        pb wifi join -s "MyNet" -p "pass" --no-discover
+    """
+    ip = discover_pixelblaze(ctx)
+    log(f"Joining network '{ssid}' from {ip}...")
+    result = Pixelblaze.setWifiConfig(ip, mode="CLIENT", ssid=ssid, passphrase=password,
+                                      discover=not no_discover, timeout=ctx.obj['timeout'])
+    jsons(result)
+    log(f"WiFi config saved — device will connect to '{ssid}'")
+    log(f"Use 'pb find' on the target network to discover the new IP")
+
+
+@cli(wifi, conn=False)
+@click.option('--ssid', '-s', required=True, help='SSID (network name) for the access point')
+@click.option('--password', '-p', default='', help='Password for the access point (leave empty for open)')
+def ap(ctx, ssid, password):
+    """
+    Configure the Pixelblaze as a WiFi access point.
+
+    Sets the Pixelblaze to create its own WiFi network with the
+    given name and optional password.
+
+    \b
+    Examples:
+        pb wifi ap -s "MyPixelblaze"        # Open AP network
+        pb wifi ap -s "MyPB" -p "secret"    # AP with password
+    """
+    ip = discover_pixelblaze(ctx)
+    log(f"Setting AP mode '{ssid}' on {ip}...")
+    result = Pixelblaze.setWifiConfig(ip, mode="AP", ssid=ssid, passphrase=password,
+                                      timeout=ctx.obj['timeout'])
+    jsons(result)
+    log(f"AP mode configured — network will be '{ssid}'")
+
+
+@cli(wifi, conn=False)
+def setup(ctx):
+    """
+    Reset WiFi to setup mode.
+
+    Puts the Pixelblaze back into initial setup mode, equivalent to
+    holding the button on boot. The device will create a 'Pixelblaze_*'
+    network for configuration.
+
+    \b
+    Examples:
+        pb wifi setup
+    """
+    ip = discover_pixelblaze(ctx)
+    log(f"Resetting to setup mode on {ip}...")
+    result = Pixelblaze.setWifiConfig(ip, mode="SETUP", timeout=ctx.obj['timeout'])
+    jsons(result)
+    log("WiFi reset to setup mode — look for a 'Pixelblaze_*' network")
+
+
+## ─── Cat ──────────────────────────────────────────────────────────────────────
+
+def _strip_js(source: str) -> str:
+    """Strip JS comments (single-line, multi-line) and blank lines."""
+    # Remove multi-line comments
+    source = re.sub(r'/\*.*?\*/', '', source, flags=re.DOTALL)
+    # Remove single-line comments (but not URLs like http://)
+    source = re.sub(r'(?<!:)//.*$', '', source, flags=re.MULTILINE)
+    # Remove blank lines
+    lines = [line for line in source.splitlines() if line.strip()]
+    return '\n'.join(lines)
+
+
+@cli(pixelblaze)
+@click.argument('path', required=False)
+@click.option('--full', is_flag=True, help='Output full source (keep comments and blank lines)')
+@click.option('--exact', is_flag=True, help='Match pattern name exactly (no regex/substring)')
+@click.option('--one', is_flag=True, help='Output only the first matching pattern (default: all matches)')
+def cat(pb: Pixelblaze, path, full, exact, one):
+    """
+    Output file or pattern source code from the Pixelblaze.
+
+    Without PATH, outputs the currently active pattern's source code.
+    With PATH, outputs ALL matching patterns' source code (use --one
+    for just the first match).
+
+    By default, strips JS comments and blank lines. Use --full to
+    output the raw, unmodified source.
+
+    \b
+    Examples:
+        pb cat                          # Active pattern source (stripped)
+        pb cat --full                   # Active pattern source (full)
+        pb cat sound                    # All patterns matching "sound"
+        pb cat sound --one              # First pattern matching "sound"
+        pb cat "color.*fade" --exact    # Exact name match
+        pb cat /config.json             # File from filesystem
+        pb cat /pixelmap.txt            # Pixel map function
+    """
+    # If path starts with /, treat as filesystem path
+    if path and path.startswith('/'):
+        log(f"Fetching file: {path}")
+        content = pb.getFile(path)
+        check(content is not None, f"File '{path}' not found on Pixelblaze")
+        try:
+            text = content.decode('utf-8')
+        except UnicodeDecodeError:
+            # Binary file — write raw bytes to stdout
+            import sys
+            sys.stdout.buffer.write(content)
+            return
+        if not full:
+            text = _strip_js(text)
+        click.echo(text)
+        return
+
+    # Pattern mode: find by name/ID, or use active pattern
+    if path:
+        if one:
+            matches = []
+            result = _find_pattern(pb, path, exact)
+            if result[0]:
+                matches = [result]
+        else:
+            matches = _find_patterns(pb, path, exact)
+        check(matches, f"No patterns matching '{path}' on Pixelblaze")
+    else:
+        log("Fetching active pattern...")
+        pattern_id = pb.getActivePattern()
+        check(pattern_id, "No active pattern running")
+        patterns = pb.getPatternList()
+        pattern_name = patterns.get(pattern_id, pattern_id)
+        matches = [(pattern_id, pattern_name)]
+
+    for i, (pattern_id, pattern_name) in enumerate(matches):
+        if len(matches) > 1:
+            if i > 0:
+                click.echo("")
+            click.echo(f"// ═══ {pattern_name} ({pattern_id}) ═══")
+
+        log(f"Fetching source: '{pattern_name}' ({pattern_id})")
+        source_code = pb.getPatternSourceCode(pattern_id)
+        if not source_code:
+            log(f"  ⚠ Failed to retrieve source for '{pattern_name}'")
+            continue
+
+        try:
+            source_obj = jsonlib.loads(source_code)
+            actual_source = source_obj.get('main', source_code)
+        except Exception:
+            actual_source = source_code
+
+        if not full:
+            actual_source = _strip_js(actual_source)
+
+        click.echo(actual_source)
+
+    if len(matches) > 1:
+        log(f"\n{len(matches)} patterns matched '{path}'")
+
+
+## ─── Filesystem ───────────────────────────────────────────────────────────────
 
 @cli(pixelblaze)
 def ls(pb: Pixelblaze):
@@ -1098,25 +1749,76 @@ def pbb(ctx, output_file, quiet, decode, binary):
 @cli(pixelblaze)
 @click.argument('input_file')
 @click.option('--quiet', '-q', is_flag=True, help='Suppress verbose progress output')
-def restore(pb: Pixelblaze, input_file, quiet):
+@click.option('--name', 'device_name', default=None,
+              help='Override the device name on the target (avoids identity clash)')
+@click.option('--keep-name', is_flag=True,
+              help="Preserve the target device's current name (don't overwrite from backup)")
+@click.option('--keep-config', is_flag=True,
+              help="Skip restoring config files entirely (only restore patterns, playlists, etc.)")
+def restore(pb: Pixelblaze, input_file, quiet, device_name, keep_name, keep_config):
     """
     Restore a Pixelblaze from a Binary Backup (.pbb file).
 
     Restores the entire Pixelblaze configuration from a .pbb backup file,
     including patterns, settings, map data, and all configuration files.
 
+    When cloning a backup to a different Pixelblaze, use --name or
+    --keep-name to avoid identity clashes (both devices having the same
+    name on the network). Use --keep-config to skip config files entirely
+    and only restore patterns and playlists.
+
     WARNING: This will overwrite all current patterns and settings!
 
     \b
     Examples:
-        pb --ip 192.168.1.24 restore backup.pbb
-        pb --ip 192.168.1.24 restore my_config.pbb
+        pb restore backup.pbb                          # Full restore
+        pb restore backup.pbb --name "Living Room 2"   # Restore with new name
+        pb restore backup.pbb --keep-name              # Keep target's current name
+        pb restore backup.pbb --keep-config            # Only restore patterns/playlists
+        pb restore backup.pbb -q                       # Quiet mode
     """
+    check(not (device_name and keep_name), "Cannot use --name and --keep-name together")
+    check(not (device_name and keep_config), "Cannot use --name and --keep-config together (--keep-config skips all config)")
+
     if not input_file.endswith('.pbb'):
         input_file += '.pbb'
 
     log(f"Restoring from {input_file}...")
     backup = PBB.fromFile(input_file)
+
+    if keep_config:
+        # Remove all config files from the backup so they won't be restored
+        # Note: PBB.deleteFile has an upstream bug (looks at top-level instead
+        # of ['files']), so we patch the backup data directly.
+        config_files = backup.getFileList(PBB.fileTypes.fileConfig)
+        if config_files:
+            import json as _json
+            _data = _json.loads(backup._PBB__textData)
+            for f in config_files:
+                if f in _data.get('files', {}):
+                    del _data['files'][f]
+                    log(f"Skipping config file: {f}")
+            backup._PBB__textData = _json.dumps(_data, indent=2)
+    elif keep_name or device_name:
+        # Determine the name to use
+        if keep_name:
+            target_name = pb.getDeviceName()
+            log(f"Preserving target device name: {target_name}")
+        else:
+            target_name = device_name
+            log(f"Overriding device name to: {target_name}")
+
+        # Patch /config.json in the backup with the desired name
+        try:
+            config_bytes = backup.getFile('/config.json')
+            config = jsonlib.loads(config_bytes.decode('utf-8'))
+            old_name = config.get('name', '(unknown)')
+            config['name'] = target_name
+            log(f"Patching config.json: name '{old_name}' → '{target_name}'")
+            backup.putFile('/config.json', jsonlib.dumps(config).encode('utf-8'))
+        except (KeyError, jsonlib.JSONDecodeError) as e:
+            log(f"Warning: could not patch config.json ({e}), restoring as-is")
+
     backup.toPixelblaze(pb, verbose=not quiet)
     log("Restore complete!")
 
@@ -1141,11 +1843,8 @@ def show():
     log("")
 
     # Show IP cache
-    ip_file = cache_dir / 'last_ip.txt'
-    if ip_file.exists():
-        log(f"Cached IP: {ip_file.read_text().strip()}")
-    else:
-        log("Cached IP: (none)")
+    last_ip = _read_cache().get('lastIp')
+    log(f"Cached IP: {last_ip}" if last_ip else "Cached IP: (none)")
 
     # Show compiler cache
     compiler_cache = cache_dir / 'compiler_cache'
@@ -1180,9 +1879,9 @@ def clear(compiler, ip):
         return
 
     if ip:
-        ip_file = cache_dir / 'last_ip.txt'
-        if ip_file.exists():
-            ip_file.unlink()
+        cache = _read_cache()
+        if cache.pop('lastIp', None) is not None:
+            _write_cache(cache)
             log("IP cache cleared")
         else:
             log("No IP cache to clear")
@@ -1279,6 +1978,124 @@ def reboot(ctx, wait):
 
         if not reconnected:
             log("Warning: Timed out waiting for device to reconnect")
+
+
+@pixelblaze.group()
+def cache():
+    """View and refresh the on-disk device cache (no network unless 'refresh')."""
+    pass
+
+
+@cache.command(name='ls')
+@click.option('--json', 'as_json', is_flag=True, help='Output one JSON object per device.')
+def cache_ls(as_json):
+    """List all cached Pixelblazes with summary info. No network calls.
+
+    \b
+    Examples:
+        pb cache ls            # human-readable summary, * marks lastIp
+        pb cache ls --json     # JSONL output for piping into jq
+    """
+    cache_data = _read_cache()
+    devices = cache_data.get('devices', {})
+    last_ip = cache_data.get('lastIp')
+    if not devices:
+        log("No cached devices. Run `pb find` to discover.")
+        return
+    for ip, entry in devices.items():
+        if as_json:
+            click.echo(jsonlib.dumps(entry, separators=(',', ':')))
+            continue
+        marker = '*' if ip == last_ip else ' '
+        name = entry.get('name', '?') or '?'
+        pixels = entry.get('pixelCount', '?')
+        ver = entry.get('ver', '?')
+        active = entry.get('activePatternName') or entry.get('activePatternId') or '-'
+        last_seen = entry.get('lastSeenAt', 'never')
+        click.echo(f"{marker} {ip:15}  {name:20}  {pixels}px  v{ver}  → {active}  @ {last_seen}")
+
+
+@cache.command(name='show')
+@click.argument('query', required=False)
+def cache_show(query):
+    """Show full cached config for a device (no network call).
+
+    QUERY is an IP, a device name, or a name substring. With no QUERY, shows lastIp.
+
+    \b
+    Examples:
+        pb cache show                  # full dump of lastIp's config
+        pb cache show jforb            # lookup by name substring
+        pb cache show 192.168.1.86     # lookup by exact IP
+    """
+    if not query:
+        last_ip = _read_cache().get('lastIp')
+        if not last_ip:
+            raise click.ClickException("No lastIp cached. Specify <ip-or-name> or run `pb find`.")
+        query = last_ip
+    ip, entry = lookup_cached_device(query)
+    click.echo(jsonlib.dumps(entry, indent=2))
+
+
+@cache.command(name='refresh')
+@click.argument('query', required=False)
+@click.option('--all', 'all_devices', is_flag=True, help='Refresh every cached device in parallel.')
+@click.option('--timeout', 'conn_timeout', type=float, default=5.0,
+              help='Per-device connection timeout in seconds.', show_default=True)
+def cache_refresh(query, all_devices, conn_timeout):
+    """Force-refresh cached config from device(s), bypassing TTL. Always fetches patterns.
+
+    \b
+    Examples:
+        pb cache refresh              # refresh lastIp
+        pb cache refresh jforb        # refresh by name substring
+        pb cache refresh --all        # refresh every cached device (parallel)
+    """
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
+    cache_data = _read_cache()
+    devices_cached = cache_data.get('devices', {})
+    if not devices_cached:
+        raise click.ClickException("No cached devices. Run `pb find` first.")
+
+    if all_devices:
+        targets = list(devices_cached.keys())
+    elif query:
+        ip, _ = lookup_cached_device(query)
+        targets = [ip]
+    else:
+        last_ip = cache_data.get('lastIp')
+        if not last_ip:
+            raise click.ClickException("Specify QUERY or --all, or set lastIp via `pb find`.")
+        targets = [last_ip]
+
+    log(f"Refreshing {len(targets)} device(s)...")
+    Pixelblaze.default_recv_timeout = conn_timeout
+
+    def _refresh_one(ip):
+        try:
+            with Pixelblaze(ip) as pb:
+                return _fetch_device_config(pb, ip=ip, include_patterns=True)
+        except Exception as e:
+            log(f"  {ip}: failed ({type(e).__name__}: {e})")
+            return None
+
+    refreshed = []
+    with ThreadPoolExecutor(max_workers=min(len(targets), 8)) as pool:
+        futures = {pool.submit(_refresh_one, ip): ip for ip in targets}
+        for fut in as_completed(futures):
+            r = fut.result()
+            if r:
+                refreshed.append(r)
+                log(f"  {r['ip']}: {r.get('name', '?')} "
+                    f"(v{r.get('ver', '?')}, {r.get('pixelCount', '?')}px, "
+                    f"{len(r.get('patterns', {}))} patterns)")
+
+    if refreshed:
+        update_device_cache(refreshed)
+        log(f"Refreshed {len(refreshed)}/{len(targets)} device(s).")
+    else:
+        raise click.ClickException("Could not refresh any devices.")
 
 
 def main():

--- a/pixelblaze/cli/cli.py
+++ b/pixelblaze/cli/cli.py
@@ -1237,6 +1237,55 @@ def setup(ctx):
     log("WiFi reset to setup mode — look for a 'Pixelblaze_*' network")
 
 
+@cli(wifi)
+def peers(pb: Pixelblaze):
+    """
+    List the sync-group members this Pixelblaze can see, including itself.
+
+    Follower devices don't broadcast LAN beacons, so `pb find` won't see
+    them via the standard discovery path. This command asks the device
+    for its current view of the sync group. The connected device is
+    prepended to the list and marked with `*`.
+
+    \b
+    Examples:
+        pb wifi peers
+        pb wifi peers --ip 192.168.1.230
+    """
+    peers = pb.getPeers()
+
+    # getPeers returns only *other* members, not self — synthesize a self row
+    # from the device's own config so users see the whole group.
+    cfg = pb.getConfigSettings()
+    self_entry = {
+        'id': cfg.get('chipId', 0),
+        'address': pb.ipAddress,
+        'name': cfg.get('name', '?'),
+        'ver': cfg.get('ver', '?'),
+        'isFollowing': 1 if cfg.get('leaderId', 0) else 0,
+        'nodeId': cfg.get('nodeId', 0),
+        'followerCount': sum(1 for p in peers if p.get('isFollowing')),
+        'self': True,
+    }
+    all_members = [self_entry] + peers
+    jsons(all_members)
+
+    log(f"\n    {'NAME':<20} {'ADDRESS':<15} {'CHIPID':>10} {'NODE':>5} {'ROLE':<10} {'VER':<6} {'FOLLOWERS':>9}")
+    log(f"    {'─' * 20} {'─' * 15} {'─' * 10} {'─' * 5} {'─' * 10} {'─' * 6} {'─' * 9}")
+    for p in all_members:
+        role = 'follower' if p.get('isFollowing') else 'leader'
+        marker = '*' if p.get('self') else ' '
+        # Firmware only fills followerCount reliably from the reporting device's
+        # own perspective. From a follower's vantage, a leader peer always
+        # reports 0 — mark that unknown instead of parroting a wrong number.
+        if p.get('self') or p.get('isFollowing'):
+            fc = str(p.get('followerCount', 0))
+        else:
+            fc = '?'
+        log(f"  {marker:<1} {p.get('name', '?'):<20} {p.get('address', '?'):<15} {p.get('id', 0):>10} "
+            f"{p.get('nodeId', 0):>5} {role:<10} {p.get('ver', '?'):<6} {fc:>9}")
+
+
 ## ─── Cat ──────────────────────────────────────────────────────────────────────
 
 def _strip_js(source: str) -> str:

--- a/pixelblaze/cli/cli_utils.py
+++ b/pixelblaze/cli/cli_utils.py
@@ -243,7 +243,10 @@ def lookup_cached_device(query: str) -> tuple[str, dict]:
     raise click.ClickException(f"No cached device matches '{query}'.")
 
 
-def _discover_ips(timeout: int = 2000) -> list[str]:
+def _discover_ips(
+    timeout: int = 2000,
+    on_ip: Optional[Callable[[str], None]] = None,
+) -> list[str]:
     """
     Discover Pixelblaze IP addresses via ad-hoc check and UDP beacons.
 
@@ -251,12 +254,25 @@ def _discover_ips(timeout: int = 2000) -> list[str]:
 
     Args:
         timeout: Beacon listen timeout in milliseconds.
+        on_ip: Optional callback invoked with each newly-discovered IP the
+            instant it's found — before the sweep completes. Lets callers
+            (e.g. `pb top`) fire workers against a device as soon as its
+            beacon arrives, instead of waiting for the full timeout + peer
+            enrichment. Callback exceptions are logged and swallowed.
 
     Returns:
         list[str]: List of discovered IP addresses.
     """
     ips = []
     seen = set()
+
+    def _report(ip: str):
+        if on_ip is None:
+            return
+        try:
+            on_ip(ip)
+        except Exception as e:
+            log(f"  on_ip callback failed for {ip}: {e}")
 
     # Check ad-hoc mode first
     adhoc_ip = "192.168.4.1"
@@ -265,6 +281,7 @@ def _discover_ips(timeout: int = 2000) -> list[str]:
         ips.append(adhoc_ip)
         seen.add(adhoc_ip)
         log(f"  Found @ {adhoc_ip} (ad-hoc)")
+        _report(adhoc_ip)
 
     # Beacon enumeration
     log(f"Listening for beacons ({timeout}ms)...")
@@ -274,6 +291,7 @@ def _discover_ips(timeout: int = 2000) -> list[str]:
                 seen.add(found_ip)
                 ips.append(found_ip)
                 log(f"  Found @ {found_ip}")
+                _report(found_ip)
     except Exception as e:
         log(f"Enumeration error: {e}")
 
@@ -289,13 +307,18 @@ def _discover_ips(timeout: int = 2000) -> list[str]:
                         seen.add(peer_ip)
                         ips.append(peer_ip)
                         log(f"  Found @ {peer_ip} (via {ip} sync group)")
+                        _report(peer_ip)
         except Exception as e:
             log(f"  Peer query failed on {ip}: {e}")
 
     return ips
 
 
-def enumerate_pixelblazes(timeout: int = 3000, slow: bool = False) -> list[dict]:
+def enumerate_pixelblazes(
+    timeout: int = 3000,
+    slow: bool = False,
+    on_ip: Optional[Callable[[str], None]] = None,
+) -> list[dict]:
     """
     Discover all Pixelblazes on the network.
 
@@ -306,12 +329,14 @@ def enumerate_pixelblazes(timeout: int = 3000, slow: bool = False) -> list[dict]
     Args:
         timeout: Beacon listen timeout in milliseconds.
         slow: If True, connect to each device to fetch full config info.
+        on_ip: Optional per-IP callback fired the instant each device is
+            found (before the sweep returns). See `_discover_ips`.
 
     Returns:
         list[dict]: Device info dicts. Fast mode: {'ip': ...} only.
                     Slow mode adds: name, pixelCount, brightness, ver, brandName, hostIp.
     """
-    ips = _discover_ips(timeout=timeout)
+    ips = _discover_ips(timeout=timeout, on_ip=on_ip)
 
     if not ips:
         return []

--- a/pixelblaze/cli/cli_utils.py
+++ b/pixelblaze/cli/cli_utils.py
@@ -2,18 +2,26 @@
 
 from __future__ import annotations
 
+import os
 import sys
+import time
 import socket
 import click
 import json5
 import json
 import pathlib
+import datetime
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from functools import wraps
 from typing import Callable, Optional
 from pixelblaze.pixelblaze import Pixelblaze
 
 log = lambda *args, **kwargs: click.echo(*args, err=True, *kwargs)
 jsons = lambda x: click.echo(json.dumps(x, separators=(',', ':')))
+
+# Opportunistic cache refresh: skip if the entry was refreshed less than this many seconds ago.
+# Override with `pb cache refresh` (force) or env PB_CACHE_TTL.
+CACHE_TTL_SECONDS = 60 * 60
 
 
 def get_cache_dir():
@@ -29,24 +37,72 @@ def get_cache_dir():
     return cache_dir
 
 
-def get_cached_ip():
-    """Get the last used IP from cache."""
+def get_host_ip() -> str:
+    """Get the local machine's outbound IP address."""
     try:
-        cache_file = get_cache_dir() / 'last_ip.txt'
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        # Standard trick: connect() a UDP socket to an unroutable address —
+        # no packets are actually sent; the kernel just resolves which local
+        # interface WOULD be used, and getsockname() reports its IP.
+        # 10.255.255.255 is the RFC 919 limited-broadcast address for the
+        # 10.0.0.0/8 private range, so this works even without a default
+        # gateway (e.g. when joined only to a PB's AP-mode SSID).
+        s.connect(('10.255.255.255', 1))
+        ip = s.getsockname()[0]
+        s.close()
+        return ip
+    except Exception:
+        return ''
+
+
+def _read_cache() -> dict:
+    """Read cache.json, returning empty structure on missing/corrupt file."""
+    try:
+        cache_file = get_cache_dir() / 'cache.json'
         if cache_file.exists():
-            return cache_file.read_text().strip()
+            return json.loads(cache_file.read_text())
     except Exception:
         pass
-    return None
+    return {'lastIp': None, 'devices': {}}
+
+
+def _write_cache(cache: dict):
+    """Write cache.json atomically."""
+    try:
+        (get_cache_dir() / 'cache.json').write_text(json.dumps(cache, indent=2))
+    except Exception:
+        pass
+
+
+def update_device_cache(devices: list[dict]):
+    """Merge device info into cache.json devices map, preserving existing richer data."""
+    cache = _read_cache()
+    known = cache.setdefault('devices', {})
+    host_ip = get_host_ip()
+    for dev in devices:
+        ip = dev.get('ip')
+        if not ip:
+            continue
+        entry = known.setdefault(ip, {'ip': ip})
+        for k, v in dev.items():
+            if v is not None and v != '':
+                entry[k] = v
+        if host_ip:
+            entry['hostIp'] = host_ip
+    _write_cache(cache)
+
+
+def get_cached_ip():
+    """Get the last used IP from cache."""
+    cache = _read_cache()
+    return cache.get('lastIp')
 
 
 def cache_ip(ip_address):
     """Cache the IP address for future use."""
-    try:
-        cache_file = get_cache_dir() / 'last_ip.txt'
-        cache_file.write_text(ip_address)
-    except Exception:
-        pass
+    cache = _read_cache()
+    cache['lastIp'] = ip_address
+    _write_cache(cache)
 
 # Reusable Click options
 no_save_option = click.option(
@@ -58,9 +114,229 @@ no_save_option = click.option(
 # Reusable Click arguments
 input_arg = click.argument('input', required=False)
 
+def _check_ip_reachable(ip: str, timeout: float = 1.0) -> bool:
+    """Check if a given IP has port 80 open (quick TCP connect check)."""
+    try:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.settimeout(timeout)
+        result = sock.connect_ex((ip, 80))
+        sock.close()
+        return result == 0
+    except Exception:
+        return False
+
+
+# Top-level keys promoted out of `settings` for quick display in `pb cache ls` / `pb find`.
+_SUMMARY_KEYS = (
+    'name', 'brandName', 'ver', 'pixelCount', 'ledType', 'dataSpeed',
+    'colorOrder', 'brightness', 'maxBrightness', 'cpuSpeed',
+    'networkPowerSave', 'sensorInputSource', 'discoveryEnable', 'timezone',
+)
+
+
+def _fetch_device_config(pb: Pixelblaze, ip: str, include_patterns: bool = True) -> dict:
+    """Fetch full basic config from a connected Pixelblaze.
+
+    Each sub-call is wrapped so a partial failure still persists what we got.
+    `include_patterns=False` skips the heavier getPatternList() call (the existing
+    cached pattern list, if any, is preserved by update_device_cache's merge).
+    """
+    info = {'ip': ip}
+
+    # getConfigSettings primes pb.latestSequencer, so getConfigSequencer below is ~free.
+    try:
+        settings = pb.getConfigSettings()
+        for key in _SUMMARY_KEYS:
+            if key in settings:
+                info[key] = settings[key]
+        info['settings'] = settings
+    except Exception as e:
+        info['settingsError'] = str(e)
+
+    try:
+        seq = pb.getConfigSequencer()
+        info['sequencer'] = seq
+        active = seq.get('activeProgram', {}) if isinstance(seq, dict) else {}
+        info['activePatternId'] = active.get('activeProgramId', '') or ''
+    except Exception as e:
+        info['sequencerError'] = str(e)
+
+    if include_patterns:
+        try:
+            patterns = pb.getPatternList()
+            info['patterns'] = patterns
+            active_id = info.get('activePatternId', '')
+            if active_id and active_id in patterns:
+                info['activePatternName'] = patterns[active_id]
+        except Exception as e:
+            info['patternsError'] = str(e)
+
+    info['lastSeenAt'] = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    return info
+
+
+def _get_device_info(ip: str) -> dict:
+    """Connect to a Pixelblaze and return a full device info dict (parallel-safe)."""
+    try:
+        with Pixelblaze(ip) as pb:
+            return _fetch_device_config(pb, ip=ip, include_patterns=True)
+    except Exception:
+        return {'ip': ip, 'name': ''}
+
+
+def _cache_is_fresh(ip: str, ttl_seconds: int = CACHE_TTL_SECONDS) -> bool:
+    """Return True if cache entry for ip exists, has a config snapshot, and is within ttl."""
+    entry = _read_cache().get('devices', {}).get(ip)
+    if not entry or 'settings' not in entry:
+        return False
+    last_seen = entry.get('lastSeenAt')
+    if not last_seen:
+        return False
+    try:
+        dt = datetime.datetime.fromisoformat(last_seen)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=datetime.timezone.utc)
+        age = (datetime.datetime.now(datetime.timezone.utc) - dt).total_seconds()
+        return age < ttl_seconds
+    except Exception:
+        return False
+
+
+def maybe_refresh_cache(pb: Pixelblaze, ip: str, force: bool = False) -> bool:
+    """Opportunistically refresh cached config for `ip` using an already-connected pb.
+
+    Silent on any failure. Returns True if a refresh was attempted.
+    Skips the patternList fetch on routine refreshes (when patterns are already cached)
+    to keep the post-command cost minimal; `force=True` always re-fetches everything.
+    """
+    try:
+        if not ip:
+            return False
+        if not force and _cache_is_fresh(ip):
+            return False
+        existing = _read_cache().get('devices', {}).get(ip, {})
+        include_patterns = force or 'patterns' not in existing
+        info = _fetch_device_config(pb, ip=ip, include_patterns=include_patterns)
+        update_device_cache([info])
+        return True
+    except Exception:
+        return False
+
+
+def lookup_cached_device(query: str) -> tuple[str, dict]:
+    """Look up a cached device by exact IP or case-insensitive name substring.
+
+    Raises click.ClickException if not found or ambiguous.
+    """
+    devices = _read_cache().get('devices', {})
+    if not devices:
+        raise click.ClickException("No cached devices. Run `pb find` first.")
+    if query in devices:
+        return query, devices[query]
+    q = query.lower()
+    matches = [(ip, e) for ip, e in devices.items() if q in (e.get('name') or '').lower()]
+    if len(matches) == 1:
+        return matches[0]
+    if len(matches) > 1:
+        names = ', '.join(f"{e.get('name', '?')} ({ip})" for ip, e in matches)
+        raise click.ClickException(f"Ambiguous query '{query}': matches {names}")
+    raise click.ClickException(f"No cached device matches '{query}'.")
+
+
+def _discover_ips(timeout: int = 2000) -> list[str]:
+    """
+    Discover Pixelblaze IP addresses via ad-hoc check and UDP beacons.
+
+    Fast — no websocket connections, just network probing.
+
+    Args:
+        timeout: Beacon listen timeout in milliseconds.
+
+    Returns:
+        list[str]: List of discovered IP addresses.
+    """
+    ips = []
+    seen = set()
+
+    # Check ad-hoc mode first
+    adhoc_ip = "192.168.4.1"
+    log(f"Checking ad-hoc ({adhoc_ip})...")
+    if _check_ip_reachable(adhoc_ip):
+        ips.append(adhoc_ip)
+        seen.add(adhoc_ip)
+        log(f"  Found @ {adhoc_ip} (ad-hoc)")
+
+    # Beacon enumeration
+    log(f"Listening for beacons ({timeout}ms)...")
+    try:
+        for found_ip in Pixelblaze.EnumerateAddresses(timeout=timeout):
+            if found_ip not in seen:
+                seen.add(found_ip)
+                ips.append(found_ip)
+                log(f"  Found @ {found_ip}")
+    except Exception as e:
+        log(f"Enumeration error: {e}")
+
+    return ips
+
+
+def enumerate_pixelblazes(timeout: int = 3000, slow: bool = False) -> list[dict]:
+    """
+    Discover all Pixelblazes on the network.
+
+    In fast mode (default), returns minimal dicts with just the IP from
+    beacon discovery. In slow mode, connects to each device in parallel
+    to fetch name, config, version, etc.
+
+    Args:
+        timeout: Beacon listen timeout in milliseconds.
+        slow: If True, connect to each device to fetch full config info.
+
+    Returns:
+        list[dict]: Device info dicts. Fast mode: {'ip': ...} only.
+                    Slow mode adds: name, pixelCount, brightness, ver, brandName, hostIp.
+    """
+    ips = _discover_ips(timeout=timeout)
+
+    if not ips:
+        return []
+
+    host_ip = get_host_ip()
+
+    if not slow:
+        devices = [{'ip': ip} for ip in ips]
+        update_device_cache(devices)
+        return devices
+
+    # Slow mode: connect to each device to get full info, in parallel
+    log(f"Fetching device info from {len(ips)} device(s)...")
+    devices = []
+    with ThreadPoolExecutor(max_workers=min(len(ips), 8)) as pool:
+        futures = {pool.submit(_get_device_info, ip): ip for ip in ips}
+        for future in as_completed(futures):
+            info = future.result()
+            if info:
+                if host_ip:
+                    info['hostIp'] = host_ip
+                devices.append(info)
+                name = info.get('name', '?')
+                if name:
+                    log(f"  {info['ip']}: {name}")
+
+    # Preserve discovery order
+    ip_order = {ip: i for i, ip in enumerate(ips)}
+    devices.sort(key=lambda d: ip_order.get(d['ip'], 999))
+
+    update_device_cache(devices)
+    return devices
+
+
 def discover_pixelblaze(ctx: click.Context) -> str:
     """
     Discovers a Pixelblaze IP address using the specified strategy.
+
+    Uses cached IP, ad-hoc check, then beacon enumeration. Returns the
+    first reachable IP and caches it.
 
     Args:
         ctx: Click context containing IP address in ctx.obj['ip']
@@ -78,49 +354,20 @@ def discover_pixelblaze(ctx: click.Context) -> str:
         return ip_address
 
     # Try cached IP first
-    cached_ip = get_cached_ip()
-    if cached_ip:
-        click.echo(f"Trying cached IP {cached_ip}...", err=True)
-        try:
-            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            sock.settimeout(1)
-            result = sock.connect_ex((cached_ip, 80))
-            sock.close()
+    cached = get_cached_ip()
+    if cached:
+        log(f"Trying cached IP {cached}...")
+        if _check_ip_reachable(cached):
+            log(f"Found Pixelblaze at {cached} (cached)")
+            return cached
+        log(f"Cached IP {cached} not responding, searching...")
 
-            if result == 0:
-                click.echo(f"Found Pixelblaze at {cached_ip} (cached)", err=True)
-                return cached_ip
-        except Exception:
-            pass
-        click.echo(f"Cached IP {cached_ip} not responding, searching...", err=True)
-
-    # Try ad-hoc mode first (192.168.4.1)
-    adhoc_ip = "192.168.4.1"
-    click.echo(f"Checking for Pixelblaze in ad-hoc mode at {adhoc_ip}...", err=True)
-
-    try:
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.settimeout(1)
-        result = sock.connect_ex((adhoc_ip, 80))
-        sock.close()
-
-        if result == 0:
-            click.echo(f"Found Pixelblaze at {adhoc_ip}", err=True)
-            cache_ip(adhoc_ip)
-            return adhoc_ip
-    except Exception as e:
-        click.echo(f"Ad-hoc check failed: {e}", err=True)
-
-    # Fall back to enumerator
-    click.echo("Searching for Pixelblazes on network...", err=True)
-
-    try:
-        for found_ip in Pixelblaze.EnumerateAddresses(timeout=2000):
-            click.echo(f"Found Pixelblaze at {found_ip}", err=True)
-            cache_ip(found_ip)
-            return found_ip
-    except Exception as e:
-        click.echo(f"Enumeration failed: {e}", err=True)
+    # Full enumeration — return first found (fast, no websocket connects)
+    ips = _discover_ips(timeout=2000)
+    if ips:
+        update_device_cache([{'ip': ip} for ip in ips])
+        cache_ip(ips[0])
+        return ips[0]
 
     raise click.ClickException(
         "No Pixelblaze found. Specify an IP address with --ip or ensure a Pixelblaze is on the network."
@@ -147,16 +394,7 @@ def read_input(value: Optional[str], name: str = "input", required: bool = True,
     Raises:
         click.ClickException: If no input provided and required=True
     """
-    import os
-
-    # Check stdin first if it's piped (not a TTY)
-    if not sys.stdin.isatty():
-        if binary:
-            return (sys.stdin.buffer.read(), True)
-        else:
-            return (sys.stdin.read().strip(), True)
-
-    # No stdin, check value
+    # If an explicit value was provided, check file path first (before stdin)
     if value is not None:
         # Check if it's an existing file path
         if os.path.isfile(value):
@@ -170,6 +408,13 @@ def read_input(value: Optional[str], name: str = "input", required: bool = True,
                 f"Cannot use inline content in binary mode. Provide a file path or pipe via stdin."
             )
         return (value, False)
+
+    # No explicit value — check stdin if it's piped (not a TTY)
+    if not sys.stdin.isatty():
+        if binary:
+            return (sys.stdin.buffer.read(), True)
+        else:
+            return (sys.stdin.read().strip(), True)
 
     # No stdin, no value
     if required:
@@ -299,9 +544,48 @@ def get_pixelblaze(ctx: click.Context) -> Pixelblaze:
     """
     discovered_ip = discover_pixelblaze(ctx)
     ctx.obj['ip'] = discovered_ip  # Update with actual IP used
+    timeout = ctx.obj.get('timeout', 5.0)
+    Pixelblaze.default_recv_timeout = timeout
     pb = Pixelblaze(discovered_ip)
     ctx.obj['pixelblaze'] = pb
     return pb
+
+
+
+# Transient errors that warrant a retry
+_RETRYABLE = (
+    ConnectionError,
+    ConnectionResetError,
+    TimeoutError,
+    OSError,
+)
+
+try:
+    import websocket
+    _RETRYABLE = _RETRYABLE + (websocket._exceptions.WebSocketTimeoutException,
+                                websocket._exceptions.WebSocketConnectionClosedException,)
+except Exception:
+    pass
+
+try:
+    import requests as _req
+    _RETRYABLE = _RETRYABLE + (_req.ConnectionError, _req.Timeout,)
+except Exception:
+    pass
+
+
+def _run_with_retries(ctx: click.Context, fn, *args, **kwargs):
+    """Run fn with retry logic on transient connection errors."""
+    max_retries = ctx.obj.get('retries', 3)
+    for attempt in range(max_retries + 1):
+        try:
+            return fn(*args, **kwargs)
+        except _RETRYABLE as e:
+            if attempt >= max_retries:
+                raise
+            delay = 0.5 * (attempt + 1)
+            log(f"Connection error ({type(e).__name__}), retry {attempt + 1}/{max_retries} in {delay:.1f}s...")
+            time.sleep(delay)
 
 
 def cli(cli_group, conn=True, **click_kwargs) -> Callable:
@@ -311,6 +595,9 @@ def cli(cli_group, conn=True, **click_kwargs) -> Callable:
     Returns a decorator that combines @click.command() and @click.pass_context functionality,
     automatically injecting a connected Pixelblaze instance as the first argument
     and wrapping the function body in a context manager.
+
+    Automatically retries on transient connection errors (ConnectionResetError,
+    timeouts, etc.) using the --retries global option.
 
     Usage:
         @cli(pixelblaze)
@@ -336,13 +623,15 @@ def cli(cli_group, conn=True, **click_kwargs) -> Callable:
     def decorator(func: Callable) -> Callable:
         @wraps(func)
         def wrapper(ctx: click.Context, *args, **kwargs):
-            if conn:
-                # Default behavior: connect and pass pb
-                with get_pixelblaze(ctx) as pb:
-                    return func(pb, *args, **kwargs)
-            else:
-                # Pass context, let function handle connection
-                return func(ctx, *args, **kwargs)
+            def _run():
+                if conn:
+                    with get_pixelblaze(ctx) as pb:
+                        result = func(pb, *args, **kwargs)
+                        maybe_refresh_cache(pb, ctx.obj.get('ip', ''))
+                        return result
+                else:
+                    return func(ctx, *args, **kwargs)
+            return _run_with_retries(ctx, _run)
 
         # Apply click.pass_context and cli.command() decorators
         wrapper = click.pass_context(wrapper)

--- a/pixelblaze/cli/cli_utils.py
+++ b/pixelblaze/cli/cli_utils.py
@@ -277,6 +277,21 @@ def _discover_ips(timeout: int = 2000) -> list[str]:
     except Exception as e:
         log(f"Enumeration error: {e}")
 
+    # Follower enrichment — follower devices don't broadcast beacons, but any
+    # beacon-visible peer knows about them via the sync group. Ask each for
+    # its peer list and union in anything new.
+    for ip in list(ips):
+        try:
+            with Pixelblaze(ip) as pb:
+                for peer in pb.getPeers():
+                    peer_ip = peer.get('address')
+                    if peer_ip and peer_ip not in seen:
+                        seen.add(peer_ip)
+                        ips.append(peer_ip)
+                        log(f"  Found @ {peer_ip} (via {ip} sync group)")
+        except Exception as e:
+            log(f"  Peer query failed on {ip}: {e}")
+
     return ips
 
 

--- a/pixelblaze/cli/top.py
+++ b/pixelblaze/cli/top.py
@@ -16,7 +16,7 @@ import sys
 import threading
 import time
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Callable, Optional
 
 import click
 
@@ -91,6 +91,37 @@ class Row:
     connected: bool = False
     error: str = ""
 
+    # Extended fields (populated by _refresh_config from getConfigSettings +
+    # getConfigSequencer). Rendered only for opt-in columns.
+    brand: str = ""
+    led_type: Optional[int] = None
+    data_speed: Optional[int] = None
+    color_order: str = ""
+    max_brightness: Optional[int] = None    # settings.maxBrightness (0-100)
+    cpu_speed: str = ""                     # settings.cpuSpeed (str: "80"/"160"/"240")
+    power_save: Optional[bool] = None       # settings.networkPowerSave
+    discovery: Optional[bool] = None        # settings.discoveryEnable
+    timezone: str = ""                      # settings.timezone
+    auto_off_enable: Optional[bool] = None  # settings.autoOffEnable
+    auto_off_start: str = ""                # settings.autoOffStart ("HH:MM")
+    auto_off_end: str = ""                  # settings.autoOffEnd
+    simple_ui: Optional[bool] = None        # settings.simpleUiMode
+    learning_ui: Optional[bool] = None      # settings.learningUiMode
+    sensor_input: Optional[int] = None      # settings.sensorInputSource (0=mic,1=exp)
+
+    # Sequencer / playlist
+    seq_mode: Optional[int] = None          # 0=Off, 1=ShuffleAll, 2=Playlist
+    seq_state: Optional[bool] = None        # runSequencer
+    seq_shuffle_ms: Optional[int] = None    # sequencer.ms — default per-item duration
+    plist_index: Optional[int] = None       # active item index (Playlist mode)
+    plist_size: Optional[int] = None        # total items in playlist
+
+    # Local tracking so we can show "time left in this pattern".
+    # Set the moment we observe active_pattern_id change (best-effort — if a
+    # pattern was already running when pb top started we can only estimate
+    # from first-observation, not true start).
+    pattern_started_at: float = 0.0         # monotonic seconds
+
 
 class TopMonitor:
     """Owns the shared rows dict, one worker thread per device, and the
@@ -131,6 +162,41 @@ class TopMonitor:
                     or dev.get("activePatternName")
                     or row.active_pattern_name
                 )
+            # Extended fields — `pb find` (slow mode) persists `settings` /
+            # `sequencer` sub-dicts into the cache; hydrate whatever we can
+            # so custom columns aren't blank until the first live refresh.
+            settings = dev.get("settings") or {}
+            row.brand = dev.get("brandName") or settings.get("brandName") or row.brand
+            row.led_type = settings.get("ledType", row.led_type)
+            row.data_speed = settings.get("dataSpeed", row.data_speed)
+            row.color_order = str(settings.get("colorOrder") or row.color_order)
+            row.max_brightness = settings.get("maxBrightness", row.max_brightness)
+            row.cpu_speed = str(settings.get("cpuSpeed") or row.cpu_speed)
+            if "networkPowerSave" in settings:
+                row.power_save = settings["networkPowerSave"]
+            if "discoveryEnable" in settings:
+                row.discovery = settings["discoveryEnable"]
+            row.timezone = str(settings.get("timezone") or row.timezone)
+            if "autoOffEnable" in settings:
+                row.auto_off_enable = settings["autoOffEnable"]
+            row.auto_off_start = str(settings.get("autoOffStart") or row.auto_off_start)
+            row.auto_off_end = str(settings.get("autoOffEnd") or row.auto_off_end)
+            if "simpleUiMode" in settings:
+                row.simple_ui = settings["simpleUiMode"]
+            if "learningUiMode" in settings:
+                row.learning_ui = settings["learningUiMode"]
+            if "sensorInputSource" in settings:
+                row.sensor_input = settings["sensorInputSource"]
+            sequencer = dev.get("sequencer") or {}
+            if "sequencerMode" in sequencer:
+                row.seq_mode = sequencer["sequencerMode"]
+            if "runSequencer" in sequencer:
+                row.seq_state = sequencer["runSequencer"]
+            if "ms" in sequencer:
+                row.seq_shuffle_ms = sequencer["ms"]
+            playlist_items = ((sequencer.get("playlist") or {}).get("items")) or []
+            if playlist_items:
+                row.plist_size = len(playlist_items)
 
     def stop(self):
         self._stop.set()
@@ -277,6 +343,23 @@ class TopMonitor:
         active_id = info.get("activePatternId", "") or ""
         patterns = info.get("patterns") or {}
         active_name = patterns.get(active_id, "") or info.get("activePatternName", "") or ""
+
+        settings = info.get("settings") or {}
+        sequencer = info.get("sequencer") or {}
+        playlist = sequencer.get("playlist") or {}
+        playlist_items = playlist.get("items") or []
+        plist_size = len(playlist_items) if playlist_items else None
+        plist_position = playlist.get("position")
+        plist_index = int(plist_position) if isinstance(plist_position, int) else None
+
+        # Detect pattern change so we can track "time left" for playlist mode.
+        with self._lock:
+            row = self._rows.get(ip)
+            prev_id = row.active_pattern_id if row else ""
+        pattern_change_kwargs = {}
+        if active_id and active_id != prev_id:
+            pattern_change_kwargs["pattern_started_at"] = time.monotonic()
+
         self._set(
             ip,
             name=info.get("name") or "",
@@ -285,6 +368,27 @@ class TopMonitor:
             brightness=info.get("brightness"),
             active_pattern_id=active_id,
             active_pattern_name=active_name,
+            brand=settings.get("brandName") or "",
+            led_type=settings.get("ledType"),
+            data_speed=settings.get("dataSpeed"),
+            color_order=str(settings.get("colorOrder") or ""),
+            max_brightness=settings.get("maxBrightness"),
+            cpu_speed=str(settings.get("cpuSpeed") or ""),
+            power_save=settings.get("networkPowerSave"),
+            discovery=settings.get("discoveryEnable"),
+            timezone=str(settings.get("timezone") or ""),
+            auto_off_enable=settings.get("autoOffEnable"),
+            auto_off_start=str(settings.get("autoOffStart") or ""),
+            auto_off_end=str(settings.get("autoOffEnd") or ""),
+            simple_ui=settings.get("simpleUiMode"),
+            learning_ui=settings.get("learningUiMode"),
+            sensor_input=settings.get("sensorInputSource"),
+            seq_mode=sequencer.get("sequencerMode"),
+            seq_state=sequencer.get("runSequencer"),
+            seq_shuffle_ms=sequencer.get("ms"),
+            plist_index=plist_index,
+            plist_size=plist_size,
+            **pattern_change_kwargs,
         )
         # Also push the fresh info into the shared JSON cache so `pb find`
         # and friends immediately benefit.
@@ -390,22 +494,299 @@ def _health(row: Row, now: float) -> tuple[str, str, str]:
     return "○", "down", "red"
 
 
-COLUMNS = [
-    # (header, width, right_align) — ordered most-important-first, since
-    # terminals narrower than the total drop trailing columns.
-    ("STATUS", 7, False),
-    ("NAME", 15, False),
-    ("IP", 15, False),
-    ("FPS", 5, True),
-    ("PATTERN", 20, False),
-    ("PIXELS", 6, True),
-    ("BRIGHT", 6, True),
-    ("STORAGE", 12, False),
-    ("MEM", 5, True),
-    ("UPTIME", 7, True),
-    ("VER", 4, True),
-    ("SEEN", 6, True),
+# ── Column registry ─────────────────────────────────────────────────────────
+# A column is a tuple of (header, width, right-aligned?, getter, description).
+# The getter receives (row, now_monotonic) and returns the raw string to render.
+# `--list-columns` prints the registry with descriptions; `--columns` picks a
+# subset by key; `--all` selects everything in registry insertion order.
+# ────────────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class ColumnSpec:
+    key: str
+    header: str
+    width: int
+    right: bool
+    get: Callable[["Row", float], str]
+    desc: str
+    group: str = "core"
+
+
+# ── Cell formatters ─────────────────────────────────────────────────────────
+
+
+LED_TYPE_NAMES = {
+    0: "none", 1: "APA102", 2: "WS2812", 3: "WS2801", 4: "buf2812", 5: "OutExp",
+}
+
+
+def _fmt_bool(v: Optional[bool], t: str = "yes", f: str = "no") -> str:
+    if v is None:
+        return "-"
+    return t if v else f
+
+
+def _fmt_int(v: Optional[int]) -> str:
+    return "-" if v is None else str(v)
+
+
+def _fmt_hz(v: Optional[int]) -> str:
+    if v is None:
+        return "-"
+    if v >= 1_000_000:
+        return f"{v / 1_000_000:.1f}M"
+    if v >= 1_000:
+        return f"{v / 1_000:.0f}k"
+    return str(v)
+
+
+SEQ_MODE_NAMES = {0: "off", 1: "shuffle", 2: "playlist"}
+
+
+def _fmt_seq_mode(row: "Row", _now: float) -> str:
+    if row.seq_mode is None:
+        return "-"
+    return SEQ_MODE_NAMES.get(row.seq_mode, str(row.seq_mode))
+
+
+def _fmt_seq_state(row: "Row", _now: float) -> str:
+    if row.seq_state is None:
+        return "-"
+    return "play" if row.seq_state else "pause"
+
+
+def _fmt_playlist_pos(row: "Row", _now: float) -> str:
+    if row.plist_size is None:
+        return "-"
+    idx = row.plist_index if row.plist_index is not None else 0
+    return f"{idx + 1}/{row.plist_size}"
+
+
+def _fmt_shuffle(row: "Row", _now: float) -> str:
+    if row.seq_shuffle_ms is None:
+        return "-"
+    ms = int(row.seq_shuffle_ms)
+    if ms >= 60_000:
+        return f"{ms // 60_000}m{(ms % 60_000) // 1000:02d}s"
+    if ms >= 1000:
+        return f"{ms / 1000:.1f}s"
+    return f"{ms}ms"
+
+
+def _fmt_playlist_left(row: "Row", now: float) -> str:
+    # Only meaningful if sequencer is running with a known per-item duration
+    # and we've seen the pattern start (either via pattern_started_at or the
+    # first observation).
+    if not row.seq_state or row.seq_shuffle_ms is None or not row.pattern_started_at:
+        return "-"
+    total = row.seq_shuffle_ms / 1000.0
+    elapsed = now - row.pattern_started_at
+    remaining = max(0.0, total - elapsed)
+    if remaining >= 60:
+        m, s = divmod(int(remaining), 60)
+        return f"{m}m{s:02d}s"
+    if remaining >= 10:
+        return f"{remaining:.0f}s"
+    return f"{remaining:.1f}s"
+
+
+def _fmt_auto_off(row: "Row", _now: float) -> str:
+    if row.auto_off_enable is None:
+        return "-"
+    if not row.auto_off_enable:
+        return "off"
+    s = row.auto_off_start or "??:??"
+    e = row.auto_off_end or "??:??"
+    return f"{s}-{e}"
+
+
+def _fmt_sensor(row: "Row", _now: float) -> str:
+    if row.sensor_input is None:
+        return "-"
+    return "expansion" if row.sensor_input else "mic"
+
+
+def _fmt_pattern(row: "Row", _now: float) -> str:
+    return row.active_pattern_name or (row.active_pattern_id[:12] if row.active_pattern_id else "-")
+
+
+def _fmt_bright(row: "Row", _now: float) -> str:
+    return f"{int(row.brightness * 100)}%" if row.brightness is not None else "-"
+
+
+def _fmt_maxbright(row: "Row", _now: float) -> str:
+    return f"{row.max_brightness}%" if row.max_brightness is not None else "-"
+
+
+def _fmt_led_type(row: "Row", _now: float) -> str:
+    if row.led_type is None:
+        return "-"
+    return LED_TYPE_NAMES.get(row.led_type, f"t{row.led_type}")
+
+
+def _fmt_status(row: "Row", now: float) -> str:
+    glyph, label, _ = _health(row, now)
+    return f"{glyph} {label}"
+
+
+def _register_columns() -> "dict[str, ColumnSpec]":
+    specs: list[ColumnSpec] = [
+        # ── Core (default set — matches the pre-registry table) ────────────
+        ColumnSpec("status",   "STATUS",   7, False, _fmt_status,
+                   "Health glyph + label", "core"),
+        ColumnSpec("name",     "NAME",    15, False, lambda r, _: r.name or "-",
+                   "Device name", "core"),
+        ColumnSpec("ip",       "IP",      15, False, lambda r, _: r.ip,
+                   "IP address", "core"),
+        ColumnSpec("fps",      "FPS",      5, True,
+                   lambda r, _: f"{r.fps:.1f}" if r.fps is not None else "-",
+                   "Frames per second (from live stats stream)", "core"),
+        ColumnSpec("pattern",  "PATTERN", 20, False, _fmt_pattern,
+                   "Active pattern name (falls back to id prefix)", "core"),
+        ColumnSpec("pixels",   "PIXELS",   6, True,
+                   lambda r, _: _fmt_int(r.pixel_count),
+                   "Configured pixel count", "core"),
+        ColumnSpec("bright",   "BRIGHT",   6, True, _fmt_bright,
+                   "Brightness slider position (0-100%)", "core"),
+        ColumnSpec("storage",  "STORAGE", 12, False, lambda r, _: _fmt_storage(r),
+                   "Flash storage used/total", "core"),
+        ColumnSpec("mem",      "MEM",      5, True, lambda r, _: _fmt_bytes(r.mem),
+                   "Free memory", "core"),
+        ColumnSpec("uptime",   "UPTIME",   7, True, lambda r, _: _fmt_uptime(r.uptime_ms),
+                   "Uptime since boot", "core"),
+        ColumnSpec("ver",      "VER",      4, True, lambda r, _: r.ver or "-",
+                   "Firmware version", "core"),
+        ColumnSpec("seen",     "SEEN",     6, True, lambda r, now: _fmt_seen(r, now),
+                   "Age of the most recent successful poll", "core"),
+
+        # ── Configuration ─────────────────────────────────────────────────
+        ColumnSpec("brand",     "BRAND",     10, False, lambda r, _: r.brand or "-",
+                   "Brand name (for OEM-rebranded firmware)", "config"),
+        ColumnSpec("patternid", "PATTERN-ID", 22, False,
+                   lambda r, _: r.active_pattern_id or "-",
+                   "Full pattern id (useful for scripting)", "config"),
+        ColumnSpec("ledtype",   "LEDTYPE",    8, False, _fmt_led_type,
+                   "LED type (WS2812, APA102, OutExp, …)", "config"),
+        ColumnSpec("dataspeed", "DATASPEED",  9, True,
+                   lambda r, _: _fmt_hz(r.data_speed),
+                   "LED data rate (Hz)", "config"),
+        ColumnSpec("colororder", "COLORORDER", 10, False, lambda r, _: r.color_order or "-",
+                   "Color order (RGB, GRB, RGBW, …)", "config"),
+        ColumnSpec("maxbright", "MAXBRIGHT",  9, True, _fmt_maxbright,
+                   "Hard brightness ceiling (0-100%)", "config"),
+        ColumnSpec("cpu",       "CPU",        4, True, lambda r, _: r.cpu_speed or "-",
+                   "CPU clock (MHz, v3-only)", "config"),
+        ColumnSpec("powersave", "PWRSAVE",    7, False,
+                   lambda r, _: _fmt_bool(r.power_save, "on", "off"),
+                   "Wi-Fi power-save mode", "config"),
+        ColumnSpec("discovery", "DISCOVERY",  9, False,
+                   lambda r, _: _fmt_bool(r.discovery, "on", "off"),
+                   "Electromage discovery + time sync", "config"),
+        ColumnSpec("timezone",  "TZ",        18, False, lambda r, _: r.timezone or "-",
+                   "Configured timezone", "config"),
+        ColumnSpec("autooff",   "AUTOOFF",   13, False, _fmt_auto_off,
+                   "Auto-off window (or 'off')", "config"),
+        ColumnSpec("simpleui",  "SIMPLEUI",   8, False,
+                   lambda r, _: _fmt_bool(r.simple_ui, "on", "off"),
+                   "Simple UI mode", "config"),
+        ColumnSpec("learning",  "LEARNING",   8, False,
+                   lambda r, _: _fmt_bool(r.learning_ui, "on", "off"),
+                   "Learning UI mode", "config"),
+        ColumnSpec("sensor",    "SENSOR",     9, False, _fmt_sensor,
+                   "Sensor input source (mic/expansion)", "config"),
+
+        # ── Sequencer / playlist ─────────────────────────────────────────
+        ColumnSpec("seqmode",   "SEQMODE",    8, False, _fmt_seq_mode,
+                   "off / shuffle / playlist", "sequencer"),
+        ColumnSpec("seqstate",  "SEQSTATE",   8, False, _fmt_seq_state,
+                   "Sequencer play/pause", "sequencer"),
+        ColumnSpec("shuffle",   "SHUFFLE",    8, True, _fmt_shuffle,
+                   "Per-item shuffle duration", "sequencer"),
+        ColumnSpec("plpos",     "PL#",        7, True, _fmt_playlist_pos,
+                   "Playlist index/total (playlist mode)", "sequencer"),
+        ColumnSpec("plleft",    "PLLEFT",     8, True, _fmt_playlist_left,
+                   "Approx time left in current pattern (playing sequencer)", "sequencer"),
+    ]
+    return {s.key: s for s in specs}
+
+
+COLUMN_SPECS: "dict[str, ColumnSpec]" = _register_columns()
+DEFAULT_COLUMN_KEYS: list[str] = [
+    "status", "name", "ip", "fps", "pattern", "pixels", "bright",
+    "storage", "mem", "uptime", "ver", "seen",
 ]
+
+# Ordered most-likely-to-change-first, so `pb top --all` puts the busy stuff
+# at the left of the table where it's easiest to scan. Identity anchors
+# (status/name/ip) come first only because you need them to read any row;
+# after that, columns cascade from "updates every stats frame" down through
+# "changes when user reconfigures" and finally "essentially static".
+ALL_COLUMN_KEYS: list[str] = [
+    # Anchors — needed to read each row
+    "status", "name", "ip",
+    # Live stats — refreshed on every {"fps":...} frame the PB pushes
+    "fps", "seen", "uptime", "mem",
+    # Pattern / sequencer runtime state — flips on shuffle / playlist / UI
+    "pattern", "plleft", "bright", "plpos", "seqstate", "seqmode", "shuffle",
+    # Slowly-growing / semi-static
+    "storage", "patternid",
+    # LED hardware config (basically only when you reconfigure)
+    "pixels", "ledtype", "colororder", "dataspeed", "maxbright", "cpu",
+    # Firmware / branding
+    "ver", "brand",
+    # Input source + power / UI / scheduling (least dynamic)
+    "sensor", "powersave", "discovery", "autooff", "timezone",
+    "simpleui", "learning",
+]
+# Sanity check at import: any registered column missing from --all is a bug.
+assert set(ALL_COLUMN_KEYS) == set(COLUMN_SPECS), (
+    f"ALL_COLUMN_KEYS out of sync with registry: "
+    f"missing={set(COLUMN_SPECS) - set(ALL_COLUMN_KEYS)}, "
+    f"extra={set(ALL_COLUMN_KEYS) - set(COLUMN_SPECS)}"
+)
+
+
+def _resolve_columns(all_flag: bool, columns_csv: Optional[str]) -> list[ColumnSpec]:
+    """Turn the CLI flags into an ordered list of ColumnSpec.
+    Precedence: --columns > --all > default. Unknown keys raise ClickException."""
+    if columns_csv:
+        keys = [k.strip().lower() for k in columns_csv.split(",") if k.strip()]
+        unknown = [k for k in keys if k not in COLUMN_SPECS]
+        if unknown:
+            raise click.ClickException(
+                f"Unknown column(s): {', '.join(unknown)}. "
+                f"Run `pb top --list-columns` to see available columns."
+            )
+        return [COLUMN_SPECS[k] for k in keys]
+    if all_flag:
+        return [COLUMN_SPECS[k] for k in ALL_COLUMN_KEYS]
+    return [COLUMN_SPECS[k] for k in DEFAULT_COLUMN_KEYS]
+
+
+def _print_column_registry():
+    """Print the column registry to stdout, grouped by section."""
+    groups: "dict[str, list[ColumnSpec]]" = {}
+    for spec in COLUMN_SPECS.values():
+        groups.setdefault(spec.group, []).append(spec)
+    order = ["core", "config", "sequencer"]
+    click.echo("Available columns (use with --columns c1,c2,...  or  --all):")
+    for group in order:
+        specs = groups.get(group, [])
+        if not specs:
+            continue
+        click.echo(f"\n  {group.title()}:")
+        for s in specs:
+            marker = "*" if s.key in DEFAULT_COLUMN_KEYS else " "
+            click.echo(f"    {marker} {s.key:<12} {s.desc}")
+    click.echo("\n  (* = shown by default)")
+    click.echo(
+        "\nNot yet available: preview-frame metrics (e.g. count of lit pixels,"
+        "\n  average color) — would require enabling binary preview frames, which"
+        "\n  adds ~30 KB/s per device to keep those frames streaming. Similarly,"
+        "\n  per-pattern sensor readings (audio bins, accelerometer) live inside"
+        "\n  pattern-exported variables and require an extra RPC per refresh."
+    )
 
 
 def _pad(s: str, width: int, right: bool) -> str:
@@ -414,27 +795,37 @@ def _pad(s: str, width: int, right: bool) -> str:
     return s.rjust(width) if right else s.ljust(width)
 
 
-def _fit_columns(term_width: int) -> list[tuple[str, int, bool]]:
-    """Return the prefix of COLUMNS whose full-width layout fits in
+def _fit_columns(term_width: int, columns: list[ColumnSpec]) -> list[ColumnSpec]:
+    """Return the prefix of `columns` whose full-width layout fits in
     `term_width`. Guarantees we never truncate mid-column, so we never
     show half a value like `1` for a SEEN of `1.2s`."""
     sep_width = 2  # matches "  ".join(...) in _render
-    picked: list[tuple[str, int, bool]] = []
+    picked: list[ColumnSpec] = []
     used = 0
-    for col in COLUMNS:
-        _, w, _ = col
-        add = w + (sep_width if picked else 0)
+    for spec in columns:
+        add = spec.width + (sep_width if picked else 0)
         if used + add > term_width:
             break
-        picked.append(col)
+        picked.append(spec)
         used += add
     # If even the first column can't fit (weirdly narrow terminal), still
     # show something rather than nothing.
-    return picked or [COLUMNS[0]]
+    return picked or [columns[0]]
 
 
 def _render(rows: list[Row], color: bool, sort_key: str,
-            active_only: bool = False) -> str:
+            active_only: bool = False,
+            columns: Optional[list[ColumnSpec]] = None,
+            truncate_to_terminal: bool = True) -> str:
+    """Render rows to a string frame.
+
+    truncate_to_terminal=True (live-tty mode): drop trailing columns that don't
+    fit the current terminal width, so the table never wraps.
+    truncate_to_terminal=False (piped / --once mode): render the full column
+    set at its natural width — `pb top --all | less -S` should show everything.
+    """
+    if columns is None:
+        columns = [COLUMN_SPECS[k] for k in DEFAULT_COLUMN_KEYS]
     now = time.monotonic()
 
     # Health rank: ok=0, stale=1, down=2. Used to pin live devices to the
@@ -470,7 +861,8 @@ def _render(rows: list[Row], color: bool, sort_key: str,
     rows = sorted(rows, key=sort_val)
 
     term_width = shutil.get_terminal_size((120, 40)).columns
-    columns = _fit_columns(term_width)
+    if truncate_to_terminal:
+        columns = _fit_columns(term_width, columns)
     lines = []
     if not rows:
         empty_msg = (
@@ -504,36 +896,15 @@ def _render(rows: list[Row], color: bool, sort_key: str,
     lines.append("")
 
     # Column headers.
-    header = "  ".join(_pad(h, w, r) for h, w, r in columns)
+    header = "  ".join(_pad(spec.header, spec.width, spec.right) for spec in columns)
     lines.append(_c(header, "grey", color))
     lines.append(_c("─" * len(header), "grey", color))
 
     for row in rows:
-        glyph, label, color_name = _health(row, now)
-        status = f"{glyph} {label}"
-        fps = f"{row.fps:.1f}" if row.fps is not None else "-"
-        mem = _fmt_bytes(row.mem)
-        storage = _fmt_storage(row)
-        pattern = row.active_pattern_name or (row.active_pattern_id[:10] if row.active_pattern_id else "-")
-        pixels = str(row.pixel_count) if row.pixel_count is not None else "-"
-        bright = f"{int(row.brightness * 100)}%" if row.brightness is not None else "-"
-        uptime = _fmt_uptime(row.uptime_ms)
-        seen = _fmt_seen(row, now)
-        cells = [
-            status,
-            row.name or "-",
-            row.ip,
-            fps,
-            pattern,
-            pixels,
-            bright,
-            storage,
-            mem,
-            uptime,
-            row.ver or "-",
-            seen,
-        ]
-        line = "  ".join(_pad(c, w, r) for c, (_, w, r) in zip(cells, columns))
+        _, label, color_name = _health(row, now)
+        line = "  ".join(
+            _pad(spec.get(row, now), spec.width, spec.right) for spec in columns
+        )
         # Color the whole row by status color (down = red, stale = yellow, ok = default).
         row_color = None if label == "ok" else color_name
         lines.append(_c(line, row_color, color) + CLEAR_LINE_END)
@@ -577,9 +948,24 @@ def register(cli_group):
                        "Cached devices we've never reached this session are hidden too.")
     @click.option("--no-color", is_flag=True, help="Disable ANSI color output.")
     @click.option("--json", "json_out", is_flag=True,
-                  help="Emit one JSON snapshot to stdout and exit (with --once).")
+                  help="Emit JSON to stdout instead of the terminal table. "
+                       "Without --once, streams one JSON array-of-rows per "
+                       "--interval tick (ndjson-style, ideal for `| jq -c`). "
+                       "With --once, emits a single snapshot and exits. "
+                       "JSON always includes every field, regardless of "
+                       "--columns / --all (those only affect the text table).")
+    @click.option("--all", "all_columns", is_flag=True,
+                  help="Show every registered column, ordered by how dynamic "
+                       "each field is (busy stuff on the left). Overridden by "
+                       "--columns if that is also given.")
+    @click.option("--columns", "columns_csv", type=str, default=None,
+                  help="Comma-separated column keys to render, in order "
+                       "(e.g. `--columns name,ip,fps,seqmode,plleft`). "
+                       "Run `pb top --list-columns` to see all keys.")
+    @click.option("--list-columns", "list_columns", is_flag=True,
+                  help="Print available columns and exit.")
     def top(interval, once, rediscover, scan_timeout, sort_key, active_only,
-            no_color, json_out):
+            no_color, json_out, all_columns, columns_csv, list_columns):
         """
         Realtime dashboard of every Pixelblaze on the network.
 
@@ -595,57 +981,80 @@ def register(cli_group):
 
         \b
         Examples:
-            pb top                        # Live dashboard, redraws every 1s
-            pb top -n 0.5                 # Faster redraw
-            pb top --sort fps             # Sort by frames-per-second
-            pb top --once                 # One snapshot, exit
-            pb top --once --json          # Machine-readable snapshot
-            pb top -r 10                  # Rediscover every 10s (default 30)
-            pb top --active               # Hide `down` rows (only live devices)
+            pb top                                    # Live dashboard, 1s redraw
+            pb top -n 0.5                             # Faster redraw
+            pb top --sort fps                         # Sort by frames-per-second
+            pb top --once                             # One snapshot, exit
+            pb top --once --json                      # One JSON snapshot, exit
+            pb top --json | jq -c '.[] | .name'       # Stream JSON per tick
+            pb top --json -n 5                        # Stream JSON every 5s
+            pb top -r 10                              # Rediscover every 10s
+            pb top --active                           # Hide `down` rows
+            pb top --all                              # Every column, busy first
+            pb top --all | less -S                    # Wide dump, one screen
+            pb top --columns name,ip,fps,seqmode,plleft
+            pb top --list-columns                     # Show the column registry
         """
-        color = sys.stdout.isatty() and not no_color
+        if list_columns:
+            _print_column_registry()
+            return
+
+        columns = _resolve_columns(all_columns, columns_csv)
+        is_tty = sys.stdout.isatty()
+        color = is_tty and not no_color
+
+        # UX guard: `pb top --all | less` should give ONE full-width dump and
+        # exit, not a stream of CLEAR_HOME frames that less can't scroll. When
+        # stdout isn't a terminal and the user didn't already ask for --json
+        # or --once, treat it as a one-shot snapshot.
+        if not is_tty and not json_out and not once:
+            once = True
+
+        def _wait_for_first_stats(monitor: TopMonitor, budget_s: float):
+            """Block up to `budget_s` for every seeded row to produce a stats
+            frame. Uses fps-is-not-None (real stats push) as the settle signal
+            — not `last_seen`, because that's now set on WS-connect too and
+            would return immediately with an empty stats block."""
+            deadline = time.monotonic() + budget_s
+            while time.monotonic() < deadline:
+                snap = monitor.snapshot()
+                if snap and all(r.fps is not None for r in snap):
+                    return
+                time.sleep(0.1)
+
+        def _filter_active(snap: list[Row]) -> list[Row]:
+            if not active_only:
+                return snap
+            _now = time.monotonic()
+            return [r for r in snap if _health(r, _now)[1] != "down"]
 
         if once:
-            # One-shot mode: run a blocking discovery so the exit snapshot
-            # actually reflects the current LAN, not just whatever we cached.
+            # One-shot: blocking discovery so the exit snapshot reflects the
+            # current LAN, not just cached IPs.
             log("Discovering Pixelblazes…")
             initial = enumerate_pixelblazes(timeout=scan_timeout, slow=False)
             if not initial:
                 raise click.ClickException("No Pixelblazes found on the network.")
             monitor = TopMonitor(initial, rediscover_seconds=rediscover)
-
-            # Config fetch takes a beat, then stats stream at ~1 Hz — give
-            # every worker enough headroom to publish at least one frame.
-            deadline = time.monotonic() + 6.0
-            while time.monotonic() < deadline:
-                if all(r.last_seen for r in monitor.snapshot()):
-                    break
-                time.sleep(0.1)
-            snap = monitor.snapshot()
+            _wait_for_first_stats(monitor, budget_s=6.0)
+            snap = _filter_active(monitor.snapshot())
             monitor.stop()
-            if active_only:
-                # Match the render-side filter so --once --json --active
-                # emits only the responding devices.
-                _now = time.monotonic()
-                snap = [r for r in snap if _health(r, _now)[1] != "down"]
             if json_out:
                 click.echo(json.dumps([_row_to_dict(r) for r in snap], separators=(",", ":")))
             else:
-                # active filter is already applied above; don't re-filter in _render.
-                click.echo(_render(snap, color=color, sort_key=sort_key))
+                # No column truncation when piped / one-shot — the user
+                # explicitly asked for what they asked for.
+                click.echo(_render(snap, color=color, sort_key=sort_key,
+                                    columns=columns, truncate_to_terminal=is_tty))
             return
 
-        # Live mode: don't block on discovery. Seed from the on-disk device
-        # cache so the table draws instantly with whatever we last knew,
-        # then let the rediscovery thread find/update everything else in
-        # the background. New devices appear as rows the moment their
-        # worker connects; devices that have moved IPs light up on the
-        # next rediscovery cycle.
+        # Live mode: seed from on-disk cache so the table (or JSON) draws
+        # instantly, then let the rediscovery thread find/update everything
+        # else in the background.
         cached = _read_cache().get("devices", {}) or {}
         seed = list(cached.values())
         monitor = TopMonitor(seed, rediscover_seconds=rediscover)
 
-        # Rediscovery thread — runs its first sweep immediately.
         threading.Thread(
             target=monitor.rediscover_loop, args=(scan_timeout,),
             daemon=True, name="pb-top-rediscover",
@@ -661,6 +1070,22 @@ def register(cli_group):
         signal.signal(signal.SIGINT, handle_signal)
         signal.signal(signal.SIGTERM, handle_signal)
 
+        if json_out:
+            # Streaming JSON: one array-per-tick, ndjson-style. No terminal
+            # escape codes, no cursor hiding — this stream is meant to be
+            # consumed by `jq`, not eyeballed.
+            try:
+                while not stop_flag["stop"]:
+                    snap = _filter_active(monitor.snapshot())
+                    click.echo(json.dumps([_row_to_dict(r) for r in snap],
+                                          separators=(",", ":")))
+                    sys.stdout.flush()
+                    time.sleep(interval)
+            finally:
+                monitor.stop()
+            return
+
+        # Live TTY render loop.
         if color:
             sys.stdout.write(HIDE_CURSOR)
             sys.stdout.flush()
@@ -668,7 +1093,7 @@ def register(cli_group):
         try:
             while not stop_flag["stop"]:
                 frame = _render(monitor.snapshot(), color=color, sort_key=sort_key,
-                                active_only=active_only)
+                                active_only=active_only, columns=columns)
                 sys.stdout.write(CLEAR_HOME + frame)
                 sys.stdout.flush()
                 time.sleep(interval)
@@ -698,4 +1123,25 @@ def _row_to_dict(r: Row) -> dict:
         "lastSeenMonotonic": r.last_seen,
         "connected": r.connected,
         "error": r.error,
+        # Extended fields (populated once _refresh_config has run at least once).
+        "brandName": r.brand,
+        "ledType": r.led_type,
+        "dataSpeed": r.data_speed,
+        "colorOrder": r.color_order,
+        "maxBrightness": r.max_brightness,
+        "cpuSpeed": r.cpu_speed,
+        "networkPowerSave": r.power_save,
+        "discoveryEnable": r.discovery,
+        "timezone": r.timezone,
+        "autoOffEnable": r.auto_off_enable,
+        "autoOffStart": r.auto_off_start,
+        "autoOffEnd": r.auto_off_end,
+        "simpleUiMode": r.simple_ui,
+        "learningUiMode": r.learning_ui,
+        "sensorInputSource": r.sensor_input,
+        "sequencerMode": r.seq_mode,
+        "sequencerState": r.seq_state,
+        "sequencerShuffleMs": r.seq_shuffle_ms,
+        "playlistIndex": r.plist_index,
+        "playlistSize": r.plist_size,
     }

--- a/pixelblaze/cli/top.py
+++ b/pixelblaze/cli/top.py
@@ -23,6 +23,7 @@ import click
 from pixelblaze.pixelblaze import Pixelblaze
 from pixelblaze.cli.cli_utils import (
     _fetch_device_config,
+    _read_cache,
     enumerate_pixelblazes,
     log,
     update_device_cache,
@@ -35,7 +36,10 @@ RESET = "\x1b[0m"
 BOLD = "\x1b[1m"
 DIM = "\x1b[2m"
 INVERT = "\x1b[7m"
-CLEAR_HOME = "\x1b[2J\x1b[H"
+# Cursor home + erase-to-end-of-screen. Some terminals treat `\x1b[2J` (erase
+# entire screen) as a scroll, which leaves ghost frames stacked in scrollback;
+# home-then-erase-down redraws cleanly everywhere.
+CLEAR_HOME = "\x1b[H\x1b[J"
 CLEAR_LINE_END = "\x1b[K"
 HIDE_CURSOR = "\x1b[?25l"
 SHOW_CURSOR = "\x1b[?25h"
@@ -101,8 +105,32 @@ class TopMonitor:
 
         for dev in initial_devices:
             ip = dev.get("ip")
-            if ip:
-                self._ensure_worker(ip)
+            if not ip:
+                continue
+            self._ensure_worker(ip)
+            # If the seed came from the on-disk cache, prime the row with
+            # its last-known name / pattern / etc. so the table isn't blank
+            # while the worker's first config fetch is in flight.
+            self._seed_row_from_cache(ip, dev)
+
+    def _seed_row_from_cache(self, ip: str, dev: dict):
+        with self._lock:
+            row = self._rows.get(ip)
+            if not row:
+                return
+            row.name = dev.get("name") or row.name
+            row.ver = str(dev.get("ver") or row.ver)
+            row.pixel_count = dev.get("pixelCount", row.pixel_count)
+            row.brightness = dev.get("brightness", row.brightness)
+            active_id = dev.get("activePatternId") or ""
+            if active_id:
+                row.active_pattern_id = active_id
+                patterns = dev.get("patterns") or {}
+                row.active_pattern_name = (
+                    patterns.get(active_id)
+                    or dev.get("activePatternName")
+                    or row.active_pattern_name
+                )
 
     def stop(self):
         self._stop.set()
@@ -222,18 +250,23 @@ class TopMonitor:
 
     def rediscover_loop(self, timeout_ms: int):
         """Background: periodically re-enumerate to pick up devices that
-        rejoined the network at a new IP or came online after startup."""
-        while not self._stop.wait(self._rediscover_seconds):
+        rejoined the network at a new IP or came online after startup.
+
+        Runs one sweep immediately (so `pb top` doesn't start with an empty
+        table when there's nothing cached) and then on a fixed interval."""
+        while not self._stop.is_set():
             try:
-                # Suppress the enumerate_pixelblazes log spam by swapping stderr
-                # briefly — the main loop owns the terminal now.
+                # Suppress the enumerate_pixelblazes log spam by swapping
+                # stderr briefly — the main loop owns the terminal now.
                 new_devices = _quiet_enumerate(timeout_ms)
             except Exception:
-                continue
+                new_devices = []
             for dev in new_devices:
                 ip = dev.get("ip")
                 if ip:
                     self._ensure_worker(ip)
+            if self._stop.wait(self._rediscover_seconds):
+                return
 
 
 def _quiet_enumerate(timeout_ms: int) -> list[dict]:
@@ -328,6 +361,25 @@ def _pad(s: str, width: int, right: bool) -> str:
     return s.rjust(width) if right else s.ljust(width)
 
 
+def _fit_columns(term_width: int) -> list[tuple[str, int, bool]]:
+    """Return the prefix of COLUMNS whose full-width layout fits in
+    `term_width`. Guarantees we never truncate mid-column, so we never
+    show half a value like `1` for a SEEN of `1.2s`."""
+    sep_width = 2  # matches "  ".join(...) in _render
+    picked: list[tuple[str, int, bool]] = []
+    used = 0
+    for col in COLUMNS:
+        _, w, _ = col
+        add = w + (sep_width if picked else 0)
+        if used + add > term_width:
+            break
+        picked.append(col)
+        used += add
+    # If even the first column can't fit (weirdly narrow terminal), still
+    # show something rather than nothing.
+    return picked or [COLUMNS[0]]
+
+
 def _render(rows: list[Row], color: bool, sort_key: str) -> str:
     now = time.monotonic()
 
@@ -343,7 +395,15 @@ def _render(rows: list[Row], color: bool, sort_key: str) -> str:
     rows = sorted(rows, key=sort_val)
 
     term_width = shutil.get_terminal_size((120, 40)).columns
+    columns = _fit_columns(term_width)
     lines = []
+    if not rows:
+        lines.append(_c(
+            " pb top  " + time.strftime("%H:%M:%S")
+            + "   waiting for discovery… (nothing cached)"
+            + CLEAR_LINE_END, "grey", color))
+        lines.append(_c("  (q or ^C to quit)", "grey", color) + CLEAR_LINE_END)
+        return "\n".join(lines)
 
     # Header line.
     total = len(rows)
@@ -361,9 +421,9 @@ def _render(rows: list[Row], color: bool, sort_key: str) -> str:
     lines.append("")
 
     # Column headers.
-    header = "  ".join(_pad(h, w, r) for h, w, r in COLUMNS)
-    lines.append(_c(header[:term_width], "grey", color))
-    lines.append(_c("─" * min(len(header), term_width), "grey", color))
+    header = "  ".join(_pad(h, w, r) for h, w, r in columns)
+    lines.append(_c(header, "grey", color))
+    lines.append(_c("─" * len(header), "grey", color))
 
     for row in rows:
         glyph, label, color_name = _health(row, now)
@@ -390,15 +450,16 @@ def _render(rows: list[Row], color: bool, sort_key: str) -> str:
             row.ver or "-",
             seen,
         ]
-        line = "  ".join(_pad(c, w, r) for c, (_, w, r) in zip(cells, COLUMNS))
-        line = line[:term_width]
+        line = "  ".join(_pad(c, w, r) for c, (_, w, r) in zip(cells, columns))
         # Color the whole row by status color (down = red, stale = yellow, ok = default).
         row_color = None if label == "ok" else color_name
         lines.append(_c(line, row_color, color) + CLEAR_LINE_END)
 
         if row.error and label != "ok":
-            err_line = _c(f"    ↳ {row.error}", "grey", color)
-            lines.append(err_line[: term_width] + CLEAR_LINE_END)
+            err_text = f"    ↳ {row.error}"
+            if len(err_text) > term_width:
+                err_text = err_text[: max(0, term_width - 1)] + "…"
+            lines.append(_c(err_text, "grey", color) + CLEAR_LINE_END)
 
     lines.append("")
     lines.append(_c("  (q or ^C to quit)", "grey", color) + CLEAR_LINE_END)
@@ -437,6 +498,11 @@ def register(cli_group):
         drop off the WiFi stay on the table as `down` and pop back to green
         when they rejoin.
 
+        Starts instantly — the initial table is seeded from the on-disk
+        device cache (whatever `pb find` / previous CLI calls last saw),
+        and a background thread runs beacon discovery on a loop to pick
+        up new/moved devices. Rows appear the moment their worker connects.
+
         \b
         Examples:
             pb top                        # Live dashboard, redraws every 1s
@@ -448,14 +514,15 @@ def register(cli_group):
         """
         color = sys.stdout.isatty() and not no_color
 
-        log("Discovering Pixelblazes…")
-        initial = enumerate_pixelblazes(timeout=scan_timeout, slow=False)
-        if not initial:
-            raise click.ClickException("No Pixelblazes found on the network.")
-
-        monitor = TopMonitor(initial, rediscover_seconds=rediscover)
-
         if once:
+            # One-shot mode: run a blocking discovery so the exit snapshot
+            # actually reflects the current LAN, not just whatever we cached.
+            log("Discovering Pixelblazes…")
+            initial = enumerate_pixelblazes(timeout=scan_timeout, slow=False)
+            if not initial:
+                raise click.ClickException("No Pixelblazes found on the network.")
+            monitor = TopMonitor(initial, rediscover_seconds=rediscover)
+
             # Config fetch takes a beat, then stats stream at ~1 Hz — give
             # every worker enough headroom to publish at least one frame.
             deadline = time.monotonic() + 6.0
@@ -471,7 +538,17 @@ def register(cli_group):
                 click.echo(_render(snap, color=color, sort_key=sort_key))
             return
 
-        # Rediscovery thread.
+        # Live mode: don't block on discovery. Seed from the on-disk device
+        # cache so the table draws instantly with whatever we last knew,
+        # then let the rediscovery thread find/update everything else in
+        # the background. New devices appear as rows the moment their
+        # worker connects; devices that have moved IPs light up on the
+        # next rediscovery cycle.
+        cached = _read_cache().get("devices", {}) or {}
+        seed = list(cached.values())
+        monitor = TopMonitor(seed, rediscover_seconds=rediscover)
+
+        # Rediscovery thread — runs its first sweep immediately.
         threading.Thread(
             target=monitor.rediscover_loop, args=(scan_timeout,),
             daemon=True, name="pb-top-rediscover",

--- a/pixelblaze/cli/top.py
+++ b/pixelblaze/cli/top.py
@@ -164,18 +164,47 @@ class TopMonitor:
         device stops responding — its inner wsReceive returns None on
         timeout, then getStatistics just tries again. Instead we drive
         wsReceive ourselves so we can bail on staleness."""
+        is_first_connect = True
         while not self._stop.is_set():
             pb: Optional[Pixelblaze] = None
             try:
                 pb = Pixelblaze(ip)
-                self._set(ip, connected=True, error="")
+                # Row visibility fast-path: a successful WS handshake IS a
+                # "we heard from this device just now" signal, so seed
+                # last_seen too. Without this the row shows as red `down`
+                # until the first stats frame lands (up to ~3s later),
+                # even though the cached name/pattern are on-screen.
+                # The stale-reconnect check uses last_stats_at, not
+                # last_seen, so this doesn't affect reconnect timing.
+                self._set(ip, connected=True, error="", last_seen=time.monotonic())
                 # Pixelblaze streams `{"fps":...}` stats frames on its own
                 # every ~1s over an open socket — no explicit sendUpdates
                 # request needed (and calling setSendPreviewFrames(True)
                 # here would also start binary preview frames, which we'd
                 # only throw away and which cost real bandwidth per device).
-                self._refresh_config(pb, ip)
-                last_config_refresh = time.monotonic()
+
+                # First-connect fast path: if the row was seeded from cache
+                # (has a name), skip the initial config fetch entirely — the
+                # cached name/pattern/etc are already on-screen, and stats
+                # will stream in ~1s. Otherwise do just getConfigSettings
+                # (the cheap one) to populate the name; skip the heavier
+                # getPatternList until the periodic refresh. The periodic
+                # refresh timer is set so a full refresh happens ~2s later.
+                if is_first_connect:
+                    with self._lock:
+                        seeded = bool(self._rows.get(ip) and self._rows[ip].name)
+                    if not seeded:
+                        # No cache seed for this row — fetch just the cheap
+                        # settings RPC so the name shows up; defer the heavy
+                        # getPatternList to the periodic refresh below.
+                        self._prime_name(pb, ip)
+                    # Force the first periodic refresh soon (~2s) so we
+                    # pick up any drift without paying the cost up-front.
+                    last_config_refresh = time.monotonic() - (CONFIG_REFRESH_SECONDS - 2.0)
+                    is_first_connect = False
+                else:
+                    self._refresh_config(pb, ip)
+                    last_config_refresh = time.monotonic()
                 last_stats_at = time.monotonic()
 
                 while not self._stop.is_set():
@@ -224,6 +253,22 @@ class TopMonitor:
             if self._stop.wait(RECONNECT_BACKOFF_SECONDS):
                 return
 
+    def _prime_name(self, pb: Pixelblaze, ip: str):
+        """Fast first-connect populate: just the cheap RPC to get the name.
+        Skips getConfigSequencer and getPatternList; the periodic refresh
+        will pick those up shortly."""
+        try:
+            settings = pb.getConfigSettings()
+            self._set(
+                ip,
+                name=settings.get("name") or "",
+                ver=str(settings.get("ver") or ""),
+                pixel_count=settings.get("pixelCount"),
+                brightness=settings.get("brightness"),
+            )
+        except Exception:
+            pass
+
     def _refresh_config(self, pb: Pixelblaze, ip: str):
         try:
             info = _fetch_device_config(pb, ip=ip, include_patterns=True)
@@ -253,30 +298,32 @@ class TopMonitor:
         rejoined the network at a new IP or came online after startup.
 
         Runs one sweep immediately (so `pb top` doesn't start with an empty
-        table when there's nothing cached) and then on a fixed interval."""
+        table when there's nothing cached) and then on a fixed interval.
+
+        Workers are spawned via `on_ip` the instant each beacon lands —
+        we don't wait for the sweep to finish. That drops first-row
+        latency for a cold cache from ~sweep-duration (ad-hoc probe +
+        full beacon timeout + serial peer enrichment) to ~one-beacon-
+        interval (usually <1s)."""
         while not self._stop.is_set():
             try:
                 # Suppress the enumerate_pixelblazes log spam by swapping
                 # stderr briefly — the main loop owns the terminal now.
-                new_devices = _quiet_enumerate(timeout_ms)
+                _quiet_enumerate(timeout_ms, on_ip=self._ensure_worker)
             except Exception:
-                new_devices = []
-            for dev in new_devices:
-                ip = dev.get("ip")
-                if ip:
-                    self._ensure_worker(ip)
+                pass
             if self._stop.wait(self._rediscover_seconds):
                 return
 
 
-def _quiet_enumerate(timeout_ms: int) -> list[dict]:
+def _quiet_enumerate(timeout_ms: int, on_ip=None) -> list[dict]:
     """Run enumerate_pixelblazes with stderr silenced (top owns the screen)."""
     import io
     import contextlib
 
     buf = io.StringIO()
     with contextlib.redirect_stderr(buf):
-        return enumerate_pixelblazes(timeout=timeout_ms, slow=False)
+        return enumerate_pixelblazes(timeout=timeout_ms, slow=False, on_ip=on_ip)
 
 
 # ── Rendering ───────────────────────────────────────────────────────────────

--- a/pixelblaze/cli/top.py
+++ b/pixelblaze/cli/top.py
@@ -383,14 +383,29 @@ def _fit_columns(term_width: int) -> list[tuple[str, int, bool]]:
 def _render(rows: list[Row], color: bool, sort_key: str) -> str:
     now = time.monotonic()
 
+    # Health rank: ok=0, stale=1, down=2. Used to pin live devices to the
+    # top of the table, both as the default sort and as a secondary key on
+    # every other sort — a dead row shouldn't leapfrog a live one just
+    # because its name happens to be alphabetically earlier.
+    health_rank = {"ok": 0, "stale": 1, "down": 2}
+    def _health_key(r: Row) -> int:
+        return health_rank[_health(r, now)[1]]
+
+    def _name_key(r: Row) -> str:
+        return (r.name or "~").lower()
+
     def sort_val(r: Row):
         if sort_key == "fps":
-            return -(r.fps or 0)  # descending
+            return (_health_key(r), -(r.fps or 0), _name_key(r))
         if sort_key == "ip":
-            return tuple(int(p) if p.isdigit() else 0 for p in r.ip.split("."))
+            octets = tuple(int(p) if p.isdigit() else 0 for p in r.ip.split("."))
+            return (_health_key(r), octets)
         if sort_key == "pattern":
-            return (r.active_pattern_name or "~").lower()
-        return (r.name or "~").lower()  # default: name
+            return (_health_key(r), (r.active_pattern_name or "~").lower(), _name_key(r))
+        if sort_key == "name":
+            return (_health_key(r), _name_key(r))
+        # Default "active": actives at the top, then alphabetical by name.
+        return (_health_key(r), _name_key(r))
 
     rows = sorted(rows, key=sort_val)
 
@@ -484,8 +499,11 @@ def register(cli_group):
                   help="Re-run beacon discovery every N seconds to pick up new devices.")
     @click.option("--scan-timeout", type=int, default=2000, show_default=True,
                   help="Beacon listen timeout for each discovery round (ms).")
-    @click.option("--sort", "sort_key", type=click.Choice(["name", "ip", "fps", "pattern"]),
-                  default="name", show_default=True, help="Sort rows by this column.")
+    @click.option("--sort", "sort_key",
+                  type=click.Choice(["active", "name", "ip", "fps", "pattern"]),
+                  default="active", show_default=True,
+                  help="Sort rows. Every option pins active devices above stale/down; "
+                       "`active` (default) then breaks ties by name.")
     @click.option("--no-color", is_flag=True, help="Disable ANSI color output.")
     @click.option("--json", "json_out", is_flag=True,
                   help="Emit one JSON snapshot to stdout and exit (with --once).")

--- a/pixelblaze/cli/top.py
+++ b/pixelblaze/cli/top.py
@@ -86,7 +86,7 @@ class Row:
     mem: Optional[int] = None
     storage_used: Optional[int] = None
     storage_size: Optional[int] = None
-    uptime: Optional[int] = None
+    uptime_ms: Optional[int] = None  # raw Pixelblaze `uptime` — milliseconds
     last_seen: float = 0.0
     connected: bool = False
     error: str = ""
@@ -196,7 +196,7 @@ class TopMonitor:
                             mem=stats.get("mem"),
                             storage_used=stats.get("storageUsed"),
                             storage_size=stats.get("storageSize"),
-                            uptime=stats.get("uptime"),
+                            uptime_ms=stats.get("uptime"),
                             last_seen=now,
                             connected=True,
                             error="",
@@ -300,17 +300,23 @@ def _fmt_storage(row: Row) -> str:
     return f"{used}/{total}"
 
 
-def _fmt_uptime(secs: Optional[int]) -> str:
-    if secs is None:
+def _fmt_uptime(ms: Optional[int]) -> str:
+    # Pixelblaze reports uptime in MILLISECONDS in its stats frames — the
+    # raw value ticks up ~1000 per second. Treating it as seconds inflates
+    # every reading 1000× (a 35-minute-old device would read as ~24 days).
+    if ms is None:
         return "-"
-    m, _ = divmod(int(secs), 60)
+    secs = int(ms) // 1000
+    m, _ = divmod(secs, 60)
     h, m = divmod(m, 60)
     d, h = divmod(h, 24)
     if d:
         return f"{d}d{h:02d}h"
     if h:
         return f"{h}h{m:02d}m"
-    return f"{m}m"
+    if m:
+        return f"{m}m"
+    return f"{secs}s"
 
 
 def _fmt_seen(row: Row, now: float) -> str:
@@ -449,7 +455,7 @@ def _render(rows: list[Row], color: bool, sort_key: str) -> str:
         pattern = row.active_pattern_name or (row.active_pattern_id[:10] if row.active_pattern_id else "-")
         pixels = str(row.pixel_count) if row.pixel_count is not None else "-"
         bright = f"{int(row.brightness * 100)}%" if row.brightness is not None else "-"
-        uptime = _fmt_uptime(row.uptime)
+        uptime = _fmt_uptime(row.uptime_ms)
         seen = _fmt_seen(row, now)
         cells = [
             status,
@@ -614,7 +620,7 @@ def _row_to_dict(r: Row) -> dict:
         "mem": r.mem,
         "storageUsed": r.storage_used,
         "storageSize": r.storage_size,
-        "uptime": r.uptime,
+        "uptimeMs": r.uptime_ms,
         "lastSeenMonotonic": r.last_seen,
         "connected": r.connected,
         "error": r.error,

--- a/pixelblaze/cli/top.py
+++ b/pixelblaze/cli/top.py
@@ -386,7 +386,8 @@ def _fit_columns(term_width: int) -> list[tuple[str, int, bool]]:
     return picked or [COLUMNS[0]]
 
 
-def _render(rows: list[Row], color: bool, sort_key: str) -> str:
+def _render(rows: list[Row], color: bool, sort_key: str,
+            active_only: bool = False) -> str:
     now = time.monotonic()
 
     # Health rank: ok=0, stale=1, down=2. Used to pin live devices to the
@@ -396,6 +397,12 @@ def _render(rows: list[Row], color: bool, sort_key: str) -> str:
     health_rank = {"ok": 0, "stale": 1, "down": 2}
     def _health_key(r: Row) -> int:
         return health_rank[_health(r, now)[1]]
+
+    hidden = 0
+    if active_only:
+        kept = [r for r in rows if _health(r, now)[1] != "down"]
+        hidden = len(rows) - len(kept)
+        rows = kept
 
     def _name_key(r: Row) -> str:
         return (r.name or "~").lower()
@@ -419,9 +426,15 @@ def _render(rows: list[Row], color: bool, sort_key: str) -> str:
     columns = _fit_columns(term_width)
     lines = []
     if not rows:
+        empty_msg = (
+            "no active devices"
+            if active_only and hidden
+            else "waiting for discovery… (nothing cached)"
+        )
         lines.append(_c(
             " pb top  " + time.strftime("%H:%M:%S")
-            + "   waiting for discovery… (nothing cached)"
+            + f"   {empty_msg}"
+            + (f"  (hidden: {hidden} down)" if hidden else "")
             + CLEAR_LINE_END, "grey", color))
         lines.append(_c("  (q or ^C to quit)", "grey", color) + CLEAR_LINE_END)
         return "\n".join(lines)
@@ -438,6 +451,8 @@ def _render(rows: list[Row], color: bool, sort_key: str) -> str:
         f"{_c(f'stale {stale}', 'yellow', color)}  "
         f"{_c(f'down {down}', 'red', color)}"
     )
+    if active_only and hidden:
+        banner += _c(f"  (hidden: {hidden} down)", "grey", color)
     lines.append(_c(banner + CLEAR_LINE_END, None, color))
     lines.append("")
 
@@ -510,10 +525,14 @@ def register(cli_group):
                   default="active", show_default=True,
                   help="Sort rows. Every option pins active devices above stale/down; "
                        "`active` (default) then breaks ties by name.")
+    @click.option("--active", "-a", "active_only", is_flag=True,
+                  help="Only show devices currently responding (hides `down` rows). "
+                       "Cached devices we've never reached this session are hidden too.")
     @click.option("--no-color", is_flag=True, help="Disable ANSI color output.")
     @click.option("--json", "json_out", is_flag=True,
                   help="Emit one JSON snapshot to stdout and exit (with --once).")
-    def top(interval, once, rediscover, scan_timeout, sort_key, no_color, json_out):
+    def top(interval, once, rediscover, scan_timeout, sort_key, active_only,
+            no_color, json_out):
         """
         Realtime dashboard of every Pixelblaze on the network.
 
@@ -535,6 +554,7 @@ def register(cli_group):
             pb top --once                 # One snapshot, exit
             pb top --once --json          # Machine-readable snapshot
             pb top -r 10                  # Rediscover every 10s (default 30)
+            pb top --active               # Hide `down` rows (only live devices)
         """
         color = sys.stdout.isatty() and not no_color
 
@@ -556,9 +576,15 @@ def register(cli_group):
                 time.sleep(0.1)
             snap = monitor.snapshot()
             monitor.stop()
+            if active_only:
+                # Match the render-side filter so --once --json --active
+                # emits only the responding devices.
+                _now = time.monotonic()
+                snap = [r for r in snap if _health(r, _now)[1] != "down"]
             if json_out:
                 click.echo(json.dumps([_row_to_dict(r) for r in snap], separators=(",", ":")))
             else:
+                # active filter is already applied above; don't re-filter in _render.
                 click.echo(_render(snap, color=color, sort_key=sort_key))
             return
 
@@ -594,7 +620,8 @@ def register(cli_group):
 
         try:
             while not stop_flag["stop"]:
-                frame = _render(monitor.snapshot(), color=color, sort_key=sort_key)
+                frame = _render(monitor.snapshot(), color=color, sort_key=sort_key,
+                                active_only=active_only)
                 sys.stdout.write(CLEAR_HOME + frame)
                 sys.stdout.flush()
                 time.sleep(interval)

--- a/pixelblaze/cli/top.py
+++ b/pixelblaze/cli/top.py
@@ -1,0 +1,526 @@
+"""`pb top` — realtime dashboard of Pixelblaze activity, `top(1)`-style.
+
+Discovers every Pixelblaze on the LAN, then keeps a long-lived websocket
+open to each and re-renders the table on a fixed interval. Devices that
+drop off the network stay on the table as `down`; if they come back
+(same IP, or a beacon rediscovery finds them at a new one), the row
+turns green again and stats resume.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import signal
+import sys
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Optional
+
+import click
+
+from pixelblaze.pixelblaze import Pixelblaze
+from pixelblaze.cli.cli_utils import (
+    _fetch_device_config,
+    enumerate_pixelblazes,
+    log,
+    update_device_cache,
+)
+
+
+# ── ANSI helpers ────────────────────────────────────────────────────────────
+
+RESET = "\x1b[0m"
+BOLD = "\x1b[1m"
+DIM = "\x1b[2m"
+INVERT = "\x1b[7m"
+CLEAR_HOME = "\x1b[2J\x1b[H"
+CLEAR_LINE_END = "\x1b[K"
+HIDE_CURSOR = "\x1b[?25l"
+SHOW_CURSOR = "\x1b[?25h"
+COLORS = {
+    "green": "\x1b[32m",
+    "yellow": "\x1b[33m",
+    "red": "\x1b[31m",
+    "cyan": "\x1b[36m",
+    "grey": "\x1b[90m",
+}
+
+
+def _c(s: str, color: Optional[str], enabled: bool) -> str:
+    if not enabled or not color:
+        return s
+    return f"{COLORS.get(color, '')}{s}{RESET}"
+
+
+# ── State ───────────────────────────────────────────────────────────────────
+
+# Health thresholds, in seconds since last successful poll.
+HEALTHY_MAX_AGE = 3.0
+STALE_MAX_AGE = 15.0
+
+# How often each worker re-fetches config/sequencer (stats stream freely on
+# their own; only pattern/name/etc need refreshing).
+CONFIG_REFRESH_SECONDS = 10.0
+
+# How often the reconnect loop retries a dead device.
+RECONNECT_BACKOFF_SECONDS = 5.0
+
+
+@dataclass
+class Row:
+    """Everything one device row on the top table needs to render itself."""
+    ip: str
+    name: str = ""
+    ver: str = ""
+    pixel_count: Optional[int] = None
+    brightness: Optional[float] = None
+    active_pattern_id: str = ""
+    active_pattern_name: str = ""
+    fps: Optional[float] = None
+    mem: Optional[int] = None
+    storage_used: Optional[int] = None
+    storage_size: Optional[int] = None
+    uptime: Optional[int] = None
+    last_seen: float = 0.0
+    connected: bool = False
+    error: str = ""
+
+
+class TopMonitor:
+    """Owns the shared rows dict, one worker thread per device, and the
+    rediscovery thread. Main loop just reads snapshots and renders."""
+
+    def __init__(self, initial_devices: list[dict], rediscover_seconds: float):
+        self._lock = threading.Lock()
+        self._rows: dict[str, Row] = {}
+        self._workers: dict[str, threading.Thread] = {}
+        self._stop = threading.Event()
+        self._rediscover_seconds = rediscover_seconds
+
+        for dev in initial_devices:
+            ip = dev.get("ip")
+            if ip:
+                self._ensure_worker(ip)
+
+    def stop(self):
+        self._stop.set()
+
+    def snapshot(self) -> list[Row]:
+        with self._lock:
+            return list(self._rows.values())
+
+    def _ensure_worker(self, ip: str):
+        with self._lock:
+            if ip in self._rows:
+                return
+            self._rows[ip] = Row(ip=ip)
+        t = threading.Thread(target=self._worker, args=(ip,), daemon=True, name=f"pb-top-{ip}")
+        self._workers[ip] = t
+        t.start()
+
+    def _set(self, ip: str, **kwargs):
+        with self._lock:
+            row = self._rows.get(ip)
+            if not row:
+                return
+            for k, v in kwargs.items():
+                setattr(row, k, v)
+
+    def _worker(self, ip: str):
+        """Per-device: keep the socket open, drain stats frames, refresh
+        config every so often. On any error, close, back off, retry.
+
+        We don't use pb.getStatistics() because it loops forever when the
+        device stops responding — its inner wsReceive returns None on
+        timeout, then getStatistics just tries again. Instead we drive
+        wsReceive ourselves so we can bail on staleness."""
+        while not self._stop.is_set():
+            pb: Optional[Pixelblaze] = None
+            try:
+                pb = Pixelblaze(ip)
+                self._set(ip, connected=True, error="")
+                # Pixelblaze streams `{"fps":...}` stats frames on its own
+                # every ~1s over an open socket — no explicit sendUpdates
+                # request needed (and calling setSendPreviewFrames(True)
+                # here would also start binary preview frames, which we'd
+                # only throw away and which cost real bandwidth per device).
+                self._refresh_config(pb, ip)
+                last_config_refresh = time.monotonic()
+                last_stats_at = time.monotonic()
+
+                while not self._stop.is_set():
+                    # Drains any binary preview frames and stashes stats/
+                    # sequencer text frames into pb.latestStats /
+                    # pb.latestSequencer. Returns after default_recv_timeout.
+                    pb.wsReceive(binaryMessageType=None)
+                    now = time.monotonic()
+                    if pb.latestStats:
+                        try:
+                            stats = json.loads(pb.latestStats)
+                        except Exception:
+                            stats = {}
+                        pb.latestStats = None
+                        self._set(
+                            ip,
+                            fps=stats.get("fps"),
+                            mem=stats.get("mem"),
+                            storage_used=stats.get("storageUsed"),
+                            storage_size=stats.get("storageSize"),
+                            uptime=stats.get("uptime"),
+                            last_seen=now,
+                            connected=True,
+                            error="",
+                        )
+                        last_stats_at = now
+
+                    if now - last_stats_at > STALE_MAX_AGE:
+                        # Peer went quiet: kick the loop so we reconnect.
+                        raise ConnectionError("no stats for >{:.0f}s".format(STALE_MAX_AGE))
+
+                    if now - last_config_refresh > CONFIG_REFRESH_SECONDS:
+                        self._refresh_config(pb, ip)
+                        last_config_refresh = time.monotonic()
+
+            except Exception as e:
+                self._set(ip, connected=False, error=str(e).splitlines()[0][:60])
+            finally:
+                if pb is not None:
+                    try:
+                        pb._close()
+                    except Exception:
+                        pass
+
+            # Backoff before reconnect.
+            if self._stop.wait(RECONNECT_BACKOFF_SECONDS):
+                return
+
+    def _refresh_config(self, pb: Pixelblaze, ip: str):
+        try:
+            info = _fetch_device_config(pb, ip=ip, include_patterns=True)
+        except Exception:
+            return
+        active_id = info.get("activePatternId", "") or ""
+        patterns = info.get("patterns") or {}
+        active_name = patterns.get(active_id, "") or info.get("activePatternName", "") or ""
+        self._set(
+            ip,
+            name=info.get("name") or "",
+            ver=str(info.get("ver") or ""),
+            pixel_count=info.get("pixelCount"),
+            brightness=info.get("brightness"),
+            active_pattern_id=active_id,
+            active_pattern_name=active_name,
+        )
+        # Also push the fresh info into the shared JSON cache so `pb find`
+        # and friends immediately benefit.
+        try:
+            update_device_cache([info])
+        except Exception:
+            pass
+
+    def rediscover_loop(self, timeout_ms: int):
+        """Background: periodically re-enumerate to pick up devices that
+        rejoined the network at a new IP or came online after startup."""
+        while not self._stop.wait(self._rediscover_seconds):
+            try:
+                # Suppress the enumerate_pixelblazes log spam by swapping stderr
+                # briefly — the main loop owns the terminal now.
+                new_devices = _quiet_enumerate(timeout_ms)
+            except Exception:
+                continue
+            for dev in new_devices:
+                ip = dev.get("ip")
+                if ip:
+                    self._ensure_worker(ip)
+
+
+def _quiet_enumerate(timeout_ms: int) -> list[dict]:
+    """Run enumerate_pixelblazes with stderr silenced (top owns the screen)."""
+    import io
+    import contextlib
+
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        return enumerate_pixelblazes(timeout=timeout_ms, slow=False)
+
+
+# ── Rendering ───────────────────────────────────────────────────────────────
+
+
+def _fmt_bytes(n: Optional[int]) -> str:
+    if n is None:
+        return "-"
+    if n < 1024:
+        return f"{n}B"
+    if n < 1024 * 1024:
+        return f"{n / 1024:.0f}K"
+    return f"{n / (1024 * 1024):.1f}M"
+
+
+def _fmt_storage(row: Row) -> str:
+    if row.storage_used is None or not row.storage_size:
+        return "-"
+    used = _fmt_bytes(row.storage_used)
+    total = _fmt_bytes(row.storage_size)
+    return f"{used}/{total}"
+
+
+def _fmt_uptime(secs: Optional[int]) -> str:
+    if secs is None:
+        return "-"
+    m, _ = divmod(int(secs), 60)
+    h, m = divmod(m, 60)
+    d, h = divmod(h, 24)
+    if d:
+        return f"{d}d{h:02d}h"
+    if h:
+        return f"{h}h{m:02d}m"
+    return f"{m}m"
+
+
+def _fmt_seen(row: Row, now: float) -> str:
+    if not row.last_seen:
+        return "never"
+    age = now - row.last_seen
+    if age < 1:
+        return f"{age * 1000:.0f}ms"
+    if age < 60:
+        return f"{age:.1f}s"
+    m, s = divmod(int(age), 60)
+    return f"{m}m{s:02d}s"
+
+
+def _health(row: Row, now: float) -> tuple[str, str, str]:
+    """Returns (status glyph, health label, color name)."""
+    age = now - row.last_seen if row.last_seen else 1e9
+    if not row.connected and age > STALE_MAX_AGE:
+        return "○", "down", "red"
+    if age <= HEALTHY_MAX_AGE:
+        return "●", "ok", "green"
+    if age <= STALE_MAX_AGE:
+        return "●", "stale", "yellow"
+    return "○", "down", "red"
+
+
+COLUMNS = [
+    # (header, width, right_align) — ordered most-important-first, since
+    # terminals narrower than the total drop trailing columns.
+    ("STATUS", 7, False),
+    ("NAME", 15, False),
+    ("IP", 15, False),
+    ("FPS", 5, True),
+    ("PATTERN", 20, False),
+    ("PIXELS", 6, True),
+    ("BRIGHT", 6, True),
+    ("STORAGE", 12, False),
+    ("MEM", 5, True),
+    ("UPTIME", 7, True),
+    ("VER", 4, True),
+    ("SEEN", 6, True),
+]
+
+
+def _pad(s: str, width: int, right: bool) -> str:
+    if len(s) > width:
+        s = s[: max(0, width - 1)] + "…"
+    return s.rjust(width) if right else s.ljust(width)
+
+
+def _render(rows: list[Row], color: bool, sort_key: str) -> str:
+    now = time.monotonic()
+
+    def sort_val(r: Row):
+        if sort_key == "fps":
+            return -(r.fps or 0)  # descending
+        if sort_key == "ip":
+            return tuple(int(p) if p.isdigit() else 0 for p in r.ip.split("."))
+        if sort_key == "pattern":
+            return (r.active_pattern_name or "~").lower()
+        return (r.name or "~").lower()  # default: name
+
+    rows = sorted(rows, key=sort_val)
+
+    term_width = shutil.get_terminal_size((120, 40)).columns
+    lines = []
+
+    # Header line.
+    total = len(rows)
+    up = sum(1 for r in rows if _health(r, now)[1] == "ok")
+    stale = sum(1 for r in rows if _health(r, now)[1] == "stale")
+    down = total - up - stale
+    ts = time.strftime("%H:%M:%S")
+    banner = (
+        f" pb top  {ts}   devices: {total}  "
+        f"{_c(f'up {up}', 'green', color)}  "
+        f"{_c(f'stale {stale}', 'yellow', color)}  "
+        f"{_c(f'down {down}', 'red', color)}"
+    )
+    lines.append(_c(banner + CLEAR_LINE_END, None, color))
+    lines.append("")
+
+    # Column headers.
+    header = "  ".join(_pad(h, w, r) for h, w, r in COLUMNS)
+    lines.append(_c(header[:term_width], "grey", color))
+    lines.append(_c("─" * min(len(header), term_width), "grey", color))
+
+    for row in rows:
+        glyph, label, color_name = _health(row, now)
+        status = f"{glyph} {label}"
+        fps = f"{row.fps:.1f}" if row.fps is not None else "-"
+        mem = _fmt_bytes(row.mem)
+        storage = _fmt_storage(row)
+        pattern = row.active_pattern_name or (row.active_pattern_id[:10] if row.active_pattern_id else "-")
+        pixels = str(row.pixel_count) if row.pixel_count is not None else "-"
+        bright = f"{int(row.brightness * 100)}%" if row.brightness is not None else "-"
+        uptime = _fmt_uptime(row.uptime)
+        seen = _fmt_seen(row, now)
+        cells = [
+            status,
+            row.name or "-",
+            row.ip,
+            fps,
+            pattern,
+            pixels,
+            bright,
+            storage,
+            mem,
+            uptime,
+            row.ver or "-",
+            seen,
+        ]
+        line = "  ".join(_pad(c, w, r) for c, (_, w, r) in zip(cells, COLUMNS))
+        line = line[:term_width]
+        # Color the whole row by status color (down = red, stale = yellow, ok = default).
+        row_color = None if label == "ok" else color_name
+        lines.append(_c(line, row_color, color) + CLEAR_LINE_END)
+
+        if row.error and label != "ok":
+            err_line = _c(f"    ↳ {row.error}", "grey", color)
+            lines.append(err_line[: term_width] + CLEAR_LINE_END)
+
+    lines.append("")
+    lines.append(_c("  (q or ^C to quit)", "grey", color) + CLEAR_LINE_END)
+    return "\n".join(lines)
+
+
+# ── Command ────────────────────────────────────────────────────────────────
+
+
+def register(cli_group):
+    """Attach `top` command to the given click group.
+
+    Kept as a function so cli.py can import and register without pulling the
+    entire implementation into module import at click's decoration time."""
+
+    @cli_group.command()
+    @click.option("--interval", "-n", type=float, default=1.0, show_default=True,
+                  help="Redraw interval in seconds.")
+    @click.option("--once", is_flag=True,
+                  help="Do a single discovery + render pass, then exit (scripting mode).")
+    @click.option("--rediscover", "-r", type=float, default=30.0, show_default=True,
+                  help="Re-run beacon discovery every N seconds to pick up new devices.")
+    @click.option("--scan-timeout", type=int, default=2000, show_default=True,
+                  help="Beacon listen timeout for each discovery round (ms).")
+    @click.option("--sort", "sort_key", type=click.Choice(["name", "ip", "fps", "pattern"]),
+                  default="name", show_default=True, help="Sort rows by this column.")
+    @click.option("--no-color", is_flag=True, help="Disable ANSI color output.")
+    @click.option("--json", "json_out", is_flag=True,
+                  help="Emit one JSON snapshot to stdout and exit (with --once).")
+    def top(interval, once, rediscover, scan_timeout, sort_key, no_color, json_out):
+        """
+        Realtime dashboard of every Pixelblaze on the network.
+
+        Like Linux `top`, but for Pixelblazes: renders a live table with
+        FPS, free storage, active pattern, uptime, and more. Devices that
+        drop off the WiFi stay on the table as `down` and pop back to green
+        when they rejoin.
+
+        \b
+        Examples:
+            pb top                        # Live dashboard, redraws every 1s
+            pb top -n 0.5                 # Faster redraw
+            pb top --sort fps             # Sort by frames-per-second
+            pb top --once                 # One snapshot, exit
+            pb top --once --json          # Machine-readable snapshot
+            pb top -r 10                  # Rediscover every 10s (default 30)
+        """
+        color = sys.stdout.isatty() and not no_color
+
+        log("Discovering Pixelblazes…")
+        initial = enumerate_pixelblazes(timeout=scan_timeout, slow=False)
+        if not initial:
+            raise click.ClickException("No Pixelblazes found on the network.")
+
+        monitor = TopMonitor(initial, rediscover_seconds=rediscover)
+
+        if once:
+            # Config fetch takes a beat, then stats stream at ~1 Hz — give
+            # every worker enough headroom to publish at least one frame.
+            deadline = time.monotonic() + 6.0
+            while time.monotonic() < deadline:
+                if all(r.last_seen for r in monitor.snapshot()):
+                    break
+                time.sleep(0.1)
+            snap = monitor.snapshot()
+            monitor.stop()
+            if json_out:
+                click.echo(json.dumps([_row_to_dict(r) for r in snap], separators=(",", ":")))
+            else:
+                click.echo(_render(snap, color=color, sort_key=sort_key))
+            return
+
+        # Rediscovery thread.
+        threading.Thread(
+            target=monitor.rediscover_loop, args=(scan_timeout,),
+            daemon=True, name="pb-top-rediscover",
+        ).start()
+
+        # SIGINT / SIGTERM → clean exit that still runs the finally block
+        # below, so we always restore the cursor before returning.
+        stop_flag = {"stop": False}
+
+        def handle_signal(_signum, _frame):
+            stop_flag["stop"] = True
+
+        signal.signal(signal.SIGINT, handle_signal)
+        signal.signal(signal.SIGTERM, handle_signal)
+
+        if color:
+            sys.stdout.write(HIDE_CURSOR)
+            sys.stdout.flush()
+
+        try:
+            while not stop_flag["stop"]:
+                frame = _render(monitor.snapshot(), color=color, sort_key=sort_key)
+                sys.stdout.write(CLEAR_HOME + frame)
+                sys.stdout.flush()
+                time.sleep(interval)
+        finally:
+            monitor.stop()
+            if color:
+                sys.stdout.write(SHOW_CURSOR + "\n")
+                sys.stdout.flush()
+
+    return top
+
+
+def _row_to_dict(r: Row) -> dict:
+    return {
+        "ip": r.ip,
+        "name": r.name,
+        "ver": r.ver,
+        "pixelCount": r.pixel_count,
+        "brightness": r.brightness,
+        "activePatternId": r.active_pattern_id,
+        "activePatternName": r.active_pattern_name,
+        "fps": r.fps,
+        "mem": r.mem,
+        "storageUsed": r.storage_used,
+        "storageSize": r.storage_size,
+        "uptime": r.uptime,
+        "lastSeenMonotonic": r.last_seen,
+        "connected": r.connected,
+        "error": r.error,
+    }

--- a/pixelblaze/pixelblaze.py
+++ b/pixelblaze/pixelblaze.py
@@ -759,14 +759,30 @@ class Pixelblaze:
             self.ws.send_binary(bytes(frameHeader) + payload[i:i + maxFrameSize])
             time.sleep(sleepTime)
 
-    def getPeers(self):
-        """A new command, added to the API but not yet implemented as of v2.29/v3.24, that will return a list of all the Pixelblazes visible on the local network segment.
+    def getPeers(self) -> list[dict]:
+        """Returns the sync-group peers this Pixelblaze is aware of.
+
+        In group-sync (leader/follower) setups, follower devices do not
+        broadcast LAN beacons on UDP:1889 — so `EnumerateAddresses` misses
+        them. `getPeers` asks the Pixelblaze for its current view of the
+        sync group, which the firmware maintains via peer-to-peer discovery.
+
+        Confirmed working on firmware v3.51.
 
         Returns:
-            TBD: To be defined once @wizard implements the function.
+            list[dict]: One entry per peer, empty list if no peers. Each entry:
+                id (int): chipId of the peer.
+                address (str): IPv4 address.
+                name (str): device name.
+                ver (str): firmware version.
+                isFollowing (int): 1 if this peer is a follower, 0 if leader/solo.
+                nodeId (int): sync-group node id.
+                followerCount (int): number of followers this peer has.
         """
-        self.wsSendJson({"getPeers": True})
-        return self.wsReceive(binaryMessageType=None)
+        response = self.wsSendJson({"getPeers": True}, expectedResponse="peers")
+        if response is None:
+            return []
+        return json.loads(response).get("peers", [])
 
     # --- PIXELBLAZE FILESYSTEM FUNCTIONS:
 

--- a/pixelblaze/pixelblaze.py
+++ b/pixelblaze/pixelblaze.py
@@ -1122,15 +1122,19 @@ class Pixelblaze:
         """
         return json.loads(self.wsSendJson({"getPlaylist": playlistId}, expectedResponse="playlist"))
 
-    def setSequencerPlaylist(self, playlistContents: dict, playlistId: str = "_defaultplaylist_"):
+    def setSequencerPlaylist(self, playlistContents: dict, playlistId: str = "_defaultplaylist_", *, saveToFlash: bool = False):
         """Replaces the entire contents of the specified playlist.  At the moment, only the default playlist is supported by the Pixelblaze.
 
         Args:
             playlistContents (dict): The new playlist contents.
             playlistId (str, optional): The name of the playlist (for future enhancement; currently only '_defaultplaylist_' is supported). Defaults to "_defaultplaylist_".
+            saveToFlash (bool, optional): If True, adds an outer `save: true` so the firmware writes the playlist to `/l/<playlistId>` (persists across reboots). Defaults to False (RAM-only — lost on reboot).
         """
         self.latestSequencer = None  # clear cache to force refresh
-        ignored = self.wsSendJson(playlistContents, expectedResponse=None)
+        payload = dict(playlistContents)
+        if saveToFlash:
+            payload['save'] = True
+        ignored = self.wsSendJson(payload, expectedResponse=None)
 
     def addToSequencerPlaylist(self, playlistContents: dict, *, patternId: str, duration: int) -> dict:
         """Appends a new entry to the specified playlist.
@@ -2249,6 +2253,95 @@ class Pixelblaze:
         if configSettings is None: configSettings = self.getConfigSettings()
         return configSettings.get('networkPowerSave', False)
 
+    # --- SETTINGS menu: WIFI settings (HTTP-only, no WebSocket required)
+
+    class wifiModes(IntEnum):
+        """WiFi operating modes reported by the Pixelblaze."""
+        modeClient = 3
+        modeAccessPoint = 6
+        modeSetup = 255
+
+    @staticmethod
+    def getWifiStatus(ipAddress: str, timeout: float = 5.0) -> dict:
+        """Returns the current WiFi status of the Pixelblaze.
+
+        This is an HTTP-only call that works even in ad-hoc/setup mode without a WebSocket connection.
+
+        Args:
+            ipAddress (str): The IP address of the Pixelblaze.
+            timeout (float): Request timeout in seconds. Defaults to 5.0.
+
+        Returns:
+            dict: WiFi status with keys: status (int), ip (str), ssid (str), mac (str).
+        """
+        response = requests.get(f"http://{ipAddress}/wifistatus", timeout=timeout)
+        response.raise_for_status()
+        return response.json()
+
+    @staticmethod
+    def getWifiScan(ipAddress: str, timeout: float = 15.0, poll_interval: float = 1.0) -> list[dict]:
+        """Scans for available WiFi access points.
+
+        This is an HTTP-only call that works even in ad-hoc/setup mode without a WebSocket connection.
+        Polls until the scan completes.
+
+        Args:
+            ipAddress (str): The IP address of the Pixelblaze.
+            timeout (float): Maximum time to wait for scan results in seconds. Defaults to 15.0.
+            poll_interval (float): Time between poll attempts in seconds. Defaults to 1.0.
+
+        Returns:
+            list[dict]: List of access points, each with keys: rssi (int), ssid (str), bssid (str), channel (int), secure (bool).
+        """
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            response = requests.get(f"http://{ipAddress}/wifiscan", timeout=5.0)
+            response.raise_for_status()
+            result = response.json()
+            if isinstance(result, list):
+                return result
+            # Still scanning — {"scanning": 1}
+            time.sleep(poll_interval)
+        return []
+
+    @staticmethod
+    def setWifiConfig(ipAddress: str, mode: str, ssid: str = "", passphrase: str = "", discover: bool = True, timeout: float = 5.0) -> dict:
+        """Sets the WiFi configuration on the Pixelblaze.
+
+        This is an HTTP-only call that works even in ad-hoc/setup mode without a WebSocket connection.
+
+        Args:
+            ipAddress (str): The IP address of the Pixelblaze.
+            mode (str): WiFi mode — "CLIENT", "AP", or "SETUP".
+            ssid (str): The SSID of the network to join or create. Defaults to "".
+            passphrase (str): The password for the network. Defaults to "".
+            discover (bool): Whether to enable Electromage discovery. Defaults to True.
+            timeout (float): Request timeout in seconds. Defaults to 5.0.
+
+        Returns:
+            dict: Response from the Pixelblaze, typically {"ack": 1}.
+        """
+        payload = {
+            "mode": mode,
+            "ssid": ssid,
+            "passphrase": passphrase,
+            "discover": "true" if discover else "false",
+        }
+        response = requests.post(
+            f"http://{ipAddress}/wifisave",
+            data=payload,
+            headers={"Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"},
+            timeout=timeout,
+        )
+        if response.status_code == 400:
+            # Return the raw response for debugging
+            raise requests.HTTPError(
+                f"400 Bad Request from /wifisave (body: {response.text!r})",
+                response=response,
+            )
+        response.raise_for_status()
+        return response.json()
+
     # --- SETTINGS menu: UPDATES settings
 
     class updateStates(IntEnum):
@@ -3134,7 +3227,23 @@ class PBP:
         # Send via WebSocket using Packet Type 1 (putSourceCode / SAVEPROGRAMSOURCEFILE)
         # The firmware expects: patternId (17 bytes) + binary blob
         payload = self.__id.encode('utf-8') + self.__binaryData
-        pb.wsSendBinary(pb.messageTypes.putSourceCode, payload, expectedResponse="ack")
+
+        # Pattern binary sending was often failing until this method of
+        # fire-and-forget with 20ms inter-chunk delay, no per-chunk ack waiting:
+        maxFrameSize = 1280
+        for i in range(0, len(payload), maxFrameSize):
+            frameHeader = bytearray(2)
+            frameHeader[0] = pb.messageTypes.putSourceCode.value  # 1
+            flags = 0
+            if i == 0:
+                flags |= 1  # START
+            if (len(payload) - i) > maxFrameSize:
+                flags |= 2  # CONTINUE
+            else:
+                flags |= 4  # END
+            frameHeader[1] = flags
+            pb.ws.send_binary(bytes(frameHeader) + payload[i:i + maxFrameSize])
+            time.sleep(0.02)
 
     def toEPE(
             self) -> 'EPE':  # 'Quoted' to defer resolution of forward reference; or could use 'from __future__ import annotations'

--- a/pixelblaze/pixelblaze.py
+++ b/pixelblaze/pixelblaze.py
@@ -731,6 +731,34 @@ class Pixelblaze:
                 self._open()
                 # raise
 
+    def wsSendBinaryChunked(self, binaryMessageType: messageTypes, payload: bytes, *, maxFrameSize: int = 1280, sleepTime: float = 0.02):
+        """Fire-and-forget chunked binary send with no per-chunk ack wait.
+
+        Sibling of `wsSendBinary` for message types where waiting on a
+        per-chunk response is unreliable (e.g. `putSourceCode`). Builds the
+        2-byte frame header internally, filling byte 1 with the continuation
+        flags for each chunk.
+
+        Args:
+            binaryMessageType (messageTypes): The binary message type to send.
+            payload (bytes): The body to send, split at `maxFrameSize`.
+            maxFrameSize (int, optional): Chunk size in bytes. Defaults to 1280.
+            sleepTime (float, optional): Delay between chunks in seconds. Defaults to 0.02.
+        """
+        frameHeader = bytearray(2)
+        frameHeader[0] = binaryMessageType.value
+        for i in range(0, len(payload), maxFrameSize):
+            flags = self.frameTypes.frameNone
+            if i == 0:
+                flags |= self.frameTypes.frameFirst
+            if (len(payload) - i) > maxFrameSize:
+                flags |= self.frameTypes.frameMiddle
+            else:
+                flags |= self.frameTypes.frameLast
+            frameHeader[1] = flags.value
+            self.ws.send_binary(bytes(frameHeader) + payload[i:i + maxFrameSize])
+            time.sleep(sleepTime)
+
     def getPeers(self):
         """A new command, added to the API but not yet implemented as of v2.29/v3.24, that will return a list of all the Pixelblazes visible on the local network segment.
 
@@ -3228,22 +3256,9 @@ class PBP:
         # The firmware expects: patternId (17 bytes) + binary blob
         payload = self.__id.encode('utf-8') + self.__binaryData
 
-        # Pattern binary sending was often failing until this method of
-        # fire-and-forget with 20ms inter-chunk delay, no per-chunk ack waiting:
-        maxFrameSize = 1280
-        for i in range(0, len(payload), maxFrameSize):
-            frameHeader = bytearray(2)
-            frameHeader[0] = pb.messageTypes.putSourceCode.value  # 1
-            flags = 0
-            if i == 0:
-                flags |= 1  # START
-            if (len(payload) - i) > maxFrameSize:
-                flags |= 2  # CONTINUE
-            else:
-                flags |= 4  # END
-            frameHeader[1] = flags
-            pb.ws.send_binary(bytes(frameHeader) + payload[i:i + maxFrameSize])
-            time.sleep(0.02)
+        # Pattern binary sending was often failing until we switched to
+        # fire-and-forget chunked send with no per-chunk ack waiting.
+        pb.wsSendBinaryChunked(pb.messageTypes.putSourceCode, payload)
 
     def toEPE(
             self) -> 'EPE':  # 'Quoted' to defer resolution of forward reference; or could use 'from __future__ import annotations'


### PR DESCRIPTION
## Summary

Ships the `pb top` realtime dashboard and the CLI expansion it sits on top of.

**`pb top` — realtime dashboard of every Pixelblaze on the LAN**
- Instant startup (seeds from the on-disk device cache; background rediscovery)
- Column registry: `--all`, `--columns key1,key2,...`, `--list-columns`
- Extended fields per row: brand, LED type, color order, max brightness, CPU speed, power-save, discovery, timezone, auto-off, sensor input, sequencer mode/state, playlist index/size/per-item ms, playlist time-left
- `--json` streams one array-per-tick (ndjson) in live mode; `--once --json` for a single snapshot
- `--active` / `-a` hides `down` rows
- `--sort` with a default that pins live devices above stale/down, then alphabetical
- Piped stdout auto-falls-back to one-shot mode so `pb top --all | less -S` gives a full-width dump instead of broken CLEAR_HOME frames
- Fixes: UPTIME was 1000× too large (stats.uptime is ms), mid-cell truncation, cleaner redraw

**Expanded `pb` subcommands**
- `pb playlist`, `pb wifi` (incl. `pb wifi peers` via real `getPeers()` + sync-group enrichment in `pb find`), `pb cfg`, `pb pattern`, `pb file`, `pb backup`
- Examples updated to cover the new subcommands

**Library-level**
- Real `getPeers()` implementation
- `wsSendBinaryChunked()` helper extracted
- WiFi HTTP methods, playlist persistence fix, `savePattern` chunking fix

## Test plan

- [x] `pb top` renders instantly, then live-updates
- [x] `pb top --all`, `pb top --columns name,ip,fps,seqmode,plleft`, `pb top --list-columns`
- [x] `pb top --json` streams ndjson every tick; `pb top --once --json` emits one snapshot
- [x] `pb top --all | less -S` shows full-width table (no escape-code stream)
- [x] `pb top --active` hides `down` rows
- [x] `pb wifi peers` lists sync-group members incl. self
- [x] `pb playlist` / `pb cfg` / `pb pattern` / `pb file` / `pb backup` smoke test

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AUWRz1vjh4YzFdrurCypBE